### PR TITLE
Enable Mirage in production

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -78,6 +78,9 @@ module.exports = function (environment) {
   }
 
   if (environment === 'production') {
+    ENV['ember-cli-mirage'] = {
+      enabled: true,
+    };
     // here you can enable a production-specific feature
     ENV.host = 'https://layers-api.planninglabs.nyc';
     ENV['mapbox-gl'].map.style = 'https://layers-api.planninglabs.nyc/v1/base/style.json';


### PR DESCRIPTION
Heads up! You will probably need this to demo a [_deployed_](https://applicantmaps-staging.planninglabs.nyc/) version of the site. I am going to leave this here for you try out. We will need to remove it once we have a real production API.