### PR TITLE
59 land use colors

### DIFF
--- a/app/components/area-map-form.js
+++ b/app/components/area-map-form.js
@@ -17,9 +17,9 @@ export default class AreaMapFormComponent extends Component {
             {
               style: {
                 paint: {
-                  'fill-opacity': .35,
-                  'fill-color': '#505050'
-                }
+                  'fill-opacity': 0.35,
+                  'fill-color': '#505050',
+                },
               },
             },
           ],
@@ -29,7 +29,7 @@ export default class AreaMapFormComponent extends Component {
           visible: true,
           layers: [
             {
-              style: { paint: { 'fill-opacity': .7 } },
+              style: { paint: { 'fill-opacity': 0.7 } },
               tooltipable: false,
             },
             {},

--- a/app/components/area-map-form.js
+++ b/app/components/area-map-form.js
@@ -11,16 +11,32 @@ export default class AreaMapFormComponent extends Component {
     store.query('layer-group', {
       'layer-groups': [
         {
+          id: 'building-footprints',
+          visible: true,
+          layers: [
+            {
+              style: {
+                paint: {
+                  'fill-opacity': .35,
+                  'fill-color': '#505050'
+                }
+              },
+            },
+          ],
+        },
+        {
           id: 'tax-lots',
           visible: true,
           layers: [
-            { tooltipable: false },
+            {
+              style: { paint: { 'fill-opacity': .7 } },
+              tooltipable: false,
+            },
             {},
             { style: { layout: { 'text-field': '{numfloors}' } } },
           ],
         },
         { id: 'subway', visible: true },
-        { id: 'building-footprints', visible: true },
         { id: 'special-purpose-districts', visible: false },
         { id: 'citymap', visible: true },
         { id: 'street-direction-arrows', visible: true },


### PR DESCRIPTION
Turned on land use colors and made building footprints darker. TRD's example maps show the building footprints as lines, not shading, so we should check with them if they'd prefer to continue only have outlines.