### PR TITLE
add zoning districts and street centerlines to project meta map, remo…

### DIFF
--- a/app/components/project-form.js
+++ b/app/components/project-form.js
@@ -89,6 +89,31 @@ export default class ProjectFormComponent extends Component {
     const navigationControl = new mapboxgl.NavigationControl();
 
     map.addControl(navigationControl, 'top-left');
+
+    const basemapLayersToHide = [
+      'highway_path',
+      'highway_minor',
+      'highway_major_casing',
+      'highway_major_inner',
+      'highway_major_subtle',
+      'highway_motorway_casing',
+      'highway_motorway_inner',
+      'highway_motorway_subtle',
+      'highway_motorway_bridge_casing',
+      'highway_motorway_bridge_inner',
+      'highway_name_other',
+      'highway_name_motorway',
+      'tunnel_motorway_casing',
+      'tunnel_motorway_inner',
+      'railway_transit',
+      'railway_transit_dashline',
+      'railway_service',
+      'railway_service_dashline',
+      'railway',
+      'railway_dashline',
+    ];
+
+    basemapLayersToHide.forEach(layer => map.removeLayer(layer));
   }
 
   @action

--- a/app/components/project-map-form.js
+++ b/app/components/project-map-form.js
@@ -17,6 +17,42 @@ export default class ProjectMapFormComponent extends Component {
             { style: { layout: { 'text-field': '{numfloors}' } } },
           ],
         },
+        {
+          id: 'zoning-districts',
+          visible: true,
+          layers: [
+            { highlightable: false, tooltipable: false },
+            { tooltipable: false },
+          ],
+        },
+        {
+          id: 'street-centerlines',
+          visible: true,
+          layers: [
+            {},
+            {
+              before: 'place_country_major',
+              style: {
+                id: 'citymap-street-centerlines-line',
+                type: 'line',
+                source: 'digital-citymap',
+                'source-layer': 'street-centerlines',
+                metadata: {
+                  'nycplanninglabs:layergroupid': 'street-centerlines',
+                },
+                minzoom: 13,
+                paint: {
+                  'line-dasharray': [
+                    5,
+                    3,
+                  ],
+                  'line-color': 'rgba(193, 193, 193, 1)',
+                  'line-width': 0.5,
+                },
+              },
+            },
+          ],
+        },
       ],
     }).then((layerGroups) => {
       const { meta } = layerGroups;


### PR DESCRIPTION
…ve standard base street features

- Adds zoning districts as a reference layer, makes sure interactivity is disabled.
- Adds street centerlines, both as a label layer AND a line layer, for reference when drawing.
- Removes street labels, streets, etc from the base layer

Closes #90