### PR TITLE
restore responsive north arrow, add mapTypeLabel to area-map model

### DIFF
--- a/app/components/map-form.js
+++ b/app/components/map-form.js
@@ -153,7 +153,6 @@ export default class MapFormComponent extends Component {
     this.set('mapInstance', map);
 
     this.fitBoundsToBuffer();
-    this.handleMapRotateOrPitch();
     this.updateBounds();
     this.toggleMapInteractions();
 
@@ -183,13 +182,6 @@ export default class MapFormComponent extends Component {
   }
 
   @action
-  handleMapRotateOrPitch() {
-    const map = this.get('mapInstance');
-    this.set('mapBearing', map.getBearing());
-    this.set('mapPitch', map.getPitch());
-  }
-
-  @action
   updateBounds() {
     const map = this.get('mapInstance');
     const canvas = map.getCanvas();
@@ -216,6 +208,9 @@ export default class MapFormComponent extends Component {
         },
       },
     });
+
+    this.set('mapBearing', map.getBearing());
+    this.set('mapPitch', map.getPitch());
   }
 
   @action
@@ -255,7 +250,6 @@ export default class MapFormComponent extends Component {
       duration: 0,
     });
 
-    this.handleMapRotateOrPitch();
     this.updateBounds();
   }
 

--- a/app/models/area-map.js
+++ b/app/models/area-map.js
@@ -1,3 +1,5 @@
 import ApplicantMap from './applicant-map';
 
-export default ApplicantMap.extend({});
+export default ApplicantMap.extend({
+  mapTypeLabel: 'Area Map',
+});

--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -245,3 +245,14 @@ label.inline {
     margin-right: 0.5rem;
   }
 }
+
+.paper-project-name {
+  font-size: 14pt;
+  margin-bottom: 0;
+}
+
+.paper-applicant {
+  font-size: 12pt;
+  margin-bottom: 0;
+  font-weight: normal;
+}

--- a/app/styles/modules/_m-legend.scss
+++ b/app/styles/modules/_m-legend.scss
@@ -11,17 +11,6 @@
   }
 }
 
-.legend-project-name {
-  font-size: 14pt;
-  margin-bottom: 0;
-}
-
-.legend-applicant {
-  font-size: 12pt;
-  margin-bottom: 0;
-  font-weight: normal;
-}
-
 .legend-section + .legend-section {
   margin-top: $global-margin/2;
 }

--- a/app/styles/modules/_m-maps.scss
+++ b/app/styles/modules/_m-maps.scss
@@ -215,13 +215,13 @@
 // Dynamic North Arrow
 // --------------------------------------------------
 #north-arrow-container {
-  position: absolute;
-  z-index: 2;
-  top: 18pt;
-  left: 16pt;
+  position: relative;
+  top: 15pt;
+  left: 0;
   width: 16pt;
   height: 16pt;
   box-sizing: border-box;
+  margin: 0 1em 0 1.5em;
 }
 
 #north-arrow {

--- a/app/templates/components/map-form.hbs
+++ b/app/templates/components/map-form.hbs
@@ -1,6 +1,7 @@
 {{#if mapConfiguration}}
+  {{log model}}
   <div class="cell sidebar">
-    <h2 class="header-large">{{model.project.projectName}} Area Map</h2>
+    <h2 class="header-large">{{model.project.projectName}} {{model.mapTypeLabel}}</h2>
 
     <hr/>
 
@@ -43,11 +44,29 @@
       <div class="paper-grid grid-x">
         <div class="cell small-3">
           <div class="grid-y" style="height:100%;">
+            <div class="cell shrink">
+              <div class="grid-x">
+                <div class="cell auto">
+                  <h1 class="paper-project-name">{{model.project.projectName}} {{model.mapTypeLabel}}</h1>
+                  <h2 class="paper-applicant">{{model.project.applicantName}}</h2>
+                </div>
+                <div class="cell shrink">
+                  <div id="north-arrow-container">
+                    <div id="north-arrow" style={{northArrowTransforms.arrow}} />
+                    <div id="north-n" style={{northArrowTransforms.n}}><span class="n" style={{northArrowTransforms.nSpan}}>N</span></div>
+                  </div>
+                </div>
+                <div class="cell small-12">
+                  <hr>
+                </div>
+              </div>
+
+            </div>
             <div class="cell shrink legend">
-              {{yield (hash 
+              {{yield (hash
                 model=model
                 mapConfiguration=mapConfiguration
-                projectAreaSource=projectAreaSource 
+                projectAreaSource=projectAreaSource
                 projectBufferSource=projectBufferSource
                 handleMapLoaded=(action 'handleMapLoaded')
                 updateBounds=(action 'updateBounds')
@@ -96,11 +115,6 @@
             {{map.on 'drag' (action 'updateBounds')}}
             {{map.on 'pitch' (action 'updateBounds')}}
             {{map.on 'rotate' (action 'updateBounds')}}
-
-            <div id="north-arrow-container">
-              <div id="north-arrow" style={{northArrowTransforms.arrow}} />
-              <div id="north-n" style={{northArrowTransforms.n}}><span class="n" style={{northArrowTransforms.nSpan}}>N</span></div>
-            </div>
           {{/labs-map}}
 
           {{!-- TODO: print a real permalink --}}

--- a/app/templates/projects/edit/map/new.hbs
+++ b/app/templates/projects/edit/map/new.hbs
@@ -1,10 +1,5 @@
 {{#map-form model=model tagName='' as |areaMapForm|}}
   <section class="legend-section">
-    <h1 class="legend-project-name">{{model.project.projectName}} Area Map</h1>
-    <h2 class="legend-applicant">{{model.project.applicantName}}</h2>
-  </section>
-  <hr>
-  <section class="legend-section">
     <h2 class="legend-section-header">Project</h2>
     {{#if model.project.projectArea}}
       {{labs-ui/legend-item item=areaMapLegendConfig.projectArea}}


### PR DESCRIPTION
- Restores dynamic north arrow by combining `handleMapRotateOrPitch` and `updateBounds` into a single action `updateBounds`
- Moves north arrow to the sidebar, next to the title
- Makes `map-form` use a dynamic `mapTypeLabel`, which is a property on the map type's model. (i.e. "Area Map") 
- Moves the map's title, applicant name, and north arrow out of the yielded legend and into `map-form`, so they will be common elements across all maps.  

Closes #80