### PR TITLE
Duplicate the new template for the edit template

### DIFF
--- a/app/templates/projects/edit/map/edit.hbs
+++ b/app/templates/projects/edit/map/edit.hbs
@@ -1,132 +1,34 @@
 {{#map-form model=model tagName='' as |areaMapForm|}}
-  <div class="cell medium-5 large-3 sidebar">
-    <h2 class="header-large">{{model.project.projectName}} Area Map</h2>
-
-    <hr/>
-
-    <div class="text-left">
-      <input type="radio" name="paper-size" value="letter" id="paper-size--letter" checked />
-      <label for="paper-size--letter">Letter</label>
-      <input type="radio" name="paper-size" value="Portrait" id="paper-size--legal" />
-      <label for="paper-size--legal">Legal</label>
-    </div>
-
-    <hr/>
-
-    <div class="text-left">
-      <input type="radio" name="paper-orientation" value="portrait" id="paper-orientation--portrait" />
-      <label for="paper-orientation--portrait">Portrait</label>
-      <input type="radio" name="paper-orientation" value="landscape" id="paper-orientation--landscape" checked />
-      <label for="paper-orientation--landscape">Landscape</label>
-    </div>
-
-    <hr/>
-
-    <button type="button" class="button project-save-button" onclick={{action areaMapForm.saveProject model}}>Save Map</button>
-  </div>
-
-  <div class="cell medium-7 large-9 paper-container">
-    <div class="paper letter landscape padding-7mm">
-      <div class="paper-grid grid-x">
-
-        <div class="cell small-3">
-          <div class="grid-y" style="height:100%;">
-            <div class="cell shrink legend">
-              <section class="legend-section">
-                <h1 class="legend-project-name">{{model.project.projectName}} Area Map</h1>
-                <h2 class="legend-applicant">{{model.project.applicantName}}</h2>
-                {{!-- {{#if model.project.description}}
-                  {{model.project.description}}
-                  {{/if}} --}}
-              </section>
-              <hr>
-              <section class="legend-section">
-                <h2 class="legend-section-header">Project</h2>
-                {{#if model.project.projectArea}}
-                  {{labs-ui/legend-item item=areaMapLegendConfig.projectArea}}
-                {{/if}}
-                {{#if model.project.developmentSite}}
-                  {{labs-ui/legend-item item=areaMapLegendConfig.developmentSite}}
-                {{/if}}
-                {{#if model.project.rezoningArea}}
-                  {{labs-ui/legend-item item=areaMapLegendConfig.rezoningArea}}
-                {{/if}}
-                {{#if model.project.projectGeometryBuffer}}
-                  {{labs-ui/legend-item item=areaMapLegendConfig.projectGeometryBuffer}}
-                {{/if}}
-              </section>
-              <section class="legend-section">
-                <h2 class="legend-section-header">Zoning</h2>
-                {{#each areaMapLegendConfig.zoningLegendItems as |item|}}
-                  {{labs-ui/legend-item item=item}}
-                {{/each}}
-              </section>
-              <section class="legend-section">
-                <h2 class="legend-section-header">Land Use</h2>
-                {{#each areaMapLegendConfig.landuseLegendItems as |item|}}
-                  {{labs-ui/legend-item item=item}}
-                {{/each}}
-              </section>
-            </div>
-            <div class="cell auto">
-              {{#if boundsPolygon}}
-                {{inset-map boundsPolygon=boundsPolygon}}
-              {{/if}}
-            </div>
-          </div>
-        </div>
-
-        <div class="cell small-9">
-          {{#labs-map
-            id='main-map'
-            initOptions=(hash
-              style=areaMapForm.mapConfiguration.meta.mapboxStyle
-              zoom=12
-              center=(array -73.983307 40.704977)
-            )
-            mapLoaded=(action areaMapForm.handleMapLoaded) as |map|
-          }}
-            {{map.labs-layers layerGroups=areaMapForm.mapConfiguration.layerGroups}}
-            {{#map.source options=(mapbox-geojson-source model.project.developmentSite) as |source|}}
-              {{source.layer
-                layer=developmentSiteLayer
-                before='boundary_country'
-              }}
-            {{/map.source}}
-
-            {{#map.source options=(mapbox-geojson-source model.project.projectArea) as |source|}}
-              {{source.layer
-                layer=projectAreaLayer
-                before='boundary_country'
-              }}
-            {{/map.source}}
-
-            {{#map.source options=(mapbox-geojson-source model.project.projectGeometryBuffer) as |source|}}
-              {{source.layer
-                layer=projectBufferLayer
-                before='boundary_country'
-              }}
-            {{/map.source}}
-
-            {{map.on 'zoom' (action areaMapForm.updateBounds)}}
-            {{map.on 'drag' (action areaMapForm.updateBounds)}}
-            {{map.on 'pitch' (action areaMapForm.updateBounds)}}
-            {{map.on 'rotate' (action areaMapForm.updateBounds)}}
-
-            <div id="north-arrow-container">
-              <div id="north-arrow" style={{northArrowTransforms.arrow}} />
-              <div id="north-n" style={{northArrowTransforms.n}}><span class="n" style={{northArrowTransforms.nSpan}}>N</span></div>
-            </div>
-          {{/labs-map}}
-
-          {{!-- TODO: print a real permalink --}}
-          <p class="text-tiny text-right">
-            <a href="">localhost:4200/projects/10/area-map</a>
-          </p>
-        </div>
-      </div>
-    </div>
-  </div>
+  <section class="legend-section">
+    <h1 class="legend-project-name">{{model.project.projectName}} Area Map</h1>
+    <h2 class="legend-applicant">{{model.project.applicantName}}</h2>
+  </section>
+  <hr>
+  <section class="legend-section">
+    <h2 class="legend-section-header">Project</h2>
+    {{#if model.project.projectArea}}
+      {{labs-ui/legend-item item=areaMapLegendConfig.projectArea}}
+    {{/if}}
+    {{#if model.project.developmentSite}}
+      {{labs-ui/legend-item item=areaMapLegendConfig.developmentSite}}
+    {{/if}}
+    {{#if model.project.rezoningArea}}
+      {{labs-ui/legend-item item=areaMapLegendConfig.rezoningArea}}
+    {{/if}}
+    {{#if model.project.projectGeometryBuffer}}
+      {{labs-ui/legend-item item=areaMapLegendConfig.projectGeometryBuffer}}
+    {{/if}}
+  </section>
+  <section class="legend-section">
+    <h2 class="legend-section-header">Zoning</h2>
+    {{#each areaMapLegendConfig.zoningLegendItems as |item|}}
+      {{labs-ui/legend-item item=item}}
+    {{/each}}
+  </section>
+  <section class="legend-section">
+    <h2 class="legend-section-header">Land Use</h2>
+    {{#each areaMapLegendConfig.landuseLegendItems as |item|}}
+      {{labs-ui/legend-item item=item}}
+    {{/each}}
+  </section>
 {{/map-form}}
-
-{{outlet}}


### PR DESCRIPTION
Copies behavior from the map/new template into the map/edit template.

We should probably have some more components for handling this legends business, if it's going to remain the structure (but configurable) across map types...