### PR TITLE
98 area map tweaks

### DIFF
--- a/app/components/map-form.js
+++ b/app/components/map-form.js
@@ -46,6 +46,27 @@ const projectBufferLayer = {
 const defaultLayerGroups = {
   'layer-groups': [
     {
+      id: 'tax-lots',
+      visible: true,
+      layers: [
+        {
+          style: {
+            paint: { 'fill-opacity': 0.5 },
+            minzoom: 8,
+          },
+          tooltipable: false,
+          highlightable: false,
+        },
+        {},
+        {
+          style: {
+            layout: { 'text-field': '{numfloors}' },
+            paint: { 'text-color': 'rgba(33, 35, 38, 0.9)' },
+          },
+        },
+      ],
+    },
+    {
       id: 'building-footprints',
       visible: true,
       layers: [
@@ -53,26 +74,11 @@ const defaultLayerGroups = {
           style: {
             paint: {
               'fill-opacity': 0.35,
-              'fill-color': '#505050',
+              'fill-color': 'rgba(33, 35, 38, 0)',
+              'fill-outline-color': 'rgba(33, 35, 38, 0.8)',
             },
           },
         },
-      ],
-    },
-    {
-      id: 'tax-lots',
-      visible: true,
-      layers: [
-        {
-          style: {
-            paint: { 'fill-opacity': 0.7 },
-            minzoom: 8,
-          },
-          tooltipable: false,
-          highlightable: false,
-        },
-        {},
-        { style: { layout: { 'text-field': '{numfloors}' } } },
       ],
     },
     { id: 'subway', visible: true },

--- a/app/components/map-form.js
+++ b/app/components/map-form.js
@@ -4,6 +4,7 @@ import { service } from '@ember-decorators/service';
 import { argument } from '@ember-decorators/argument';
 import { next } from '@ember/runloop';
 import turfBbox from 'npm:@turf/bbox';
+import mapboxgl from 'mapbox-gl';
 
 const developmentSiteLayer = {
   id: 'development-site-line',
@@ -176,6 +177,9 @@ export default class MapFormComponent extends Component {
     this.fitBoundsToBuffer();
     this.updateBounds();
     this.toggleMapInteractions();
+
+    const scaleControl = new mapboxgl.ScaleControl({ maxWidth: 200, unit: 'imperial' });
+    map.addControl(scaleControl, 'bottom-left');
 
     const basemapLayersToHide = [
       'highway_path',

--- a/app/styles/modules/_m-legend.scss
+++ b/app/styles/modules/_m-legend.scss
@@ -62,4 +62,8 @@
     &.c2-4 { background-position: -60px -50px; }
     &.c2-5 { background-position: -10px -60px; }
   }
+
+  .land-use-section-cell & {
+    opacity: 0.6;
+  }
 }


### PR DESCRIPTION
This PR closes #98 by… 
- Increasing the transparency of the Land Use colors
- Adding `scaleControl`
- Switch building footprints from fill to a thin line (We may want to revisit this. Using OSM data for this gets us all the info used for extrusions and seems to inaccurately cross tax lot boundaries.) 