### PR TITLE
zoom extent updates after paper resizing

### DIFF
--- a/app/components/map-form.js
+++ b/app/components/map-form.js
@@ -244,6 +244,7 @@ export default class MapFormComponent extends Component {
     next(() => {
       // not supported in IE 11
       window.addEventListener('resize', () => {
+        this.fitBoundsToBuffer();
         this.updateBounds();
       });
       // not supported in IE 11
@@ -257,6 +258,7 @@ export default class MapFormComponent extends Component {
     next(() => {
       // not supported in IE 11
       window.addEventListener('resize', () => {
+        this.fitBoundsToBuffer();
         this.updateBounds();
       });
       // not supported in IE 11


### PR DESCRIPTION
Fixes #117 by adding this.fitBoundsToBuffer() to the scalePaper() and reorientPaper() functions.