### PR TITLE
Subway Legend

### DIFF
--- a/app/components/inset-map.js
+++ b/app/components/inset-map.js
@@ -17,7 +17,7 @@ class InsetMap extends Component {
     this.set('mapInstance', map);
     const bounds = this.get('boundsPolygon');
 
-    map.fitBounds(turfBbox.default(turfBuffer.default(bounds, 3)), {
+    map.fitBounds(turfBbox.default(turfBuffer.default(bounds, 12)), {
       duration: 0,
     });
   }

--- a/app/components/map-form.js
+++ b/app/components/map-form.js
@@ -9,7 +9,37 @@ import projectGeomLayers from '../utils/project-geom-layers';
 
 const defaultLayerGroups = {
   'layer-groups': [
-    { id: 'subway', visible: true },
+    {
+      id: 'subway',
+      visible: true,
+      layers: [
+        {}, // subway_green
+        {}, // subway_yellow
+        {}, // subway_gray
+        {}, // subway_brown
+        {}, // subway_light_green
+        {}, // subway_orange
+        {}, // subway_blue
+        {}, // subway_purple
+        {}, // subway_red
+        {}, // subway_stations
+        {}, // subway_stations_labels
+        {
+          style: {
+            paint: {
+              'circle-stroke-width': 1.5,
+            },
+          },
+        }, // subway_entrances
+        {
+          style: {
+            paint: {
+              'text-opacity': 0,
+            },
+          },
+        }, // subway_entrances_labels
+      ],
+    },
     {
       id: 'tax-lots',
       visible: true,

--- a/app/components/map-form.js
+++ b/app/components/map-form.js
@@ -5,44 +5,7 @@ import { argument } from '@ember-decorators/argument';
 import { next } from '@ember/runloop';
 import turfBbox from 'npm:@turf/bbox';
 import mapboxgl from 'mapbox-gl';
-
-const developmentSiteLayer = {
-  id: 'development-site-line',
-  type: 'line',
-  paint: {
-    'line-width': 2,
-    'line-color': 'red',
-  },
-};
-
-const projectAreaLayer = {
-  id: 'project-area-line',
-  type: 'line',
-  layout: {
-    visibility: 'visible',
-    'line-cap': 'round',
-  },
-  paint: {
-    'line-width': 3,
-    'line-dasharray': [
-      0,
-      2,
-    ],
-  },
-};
-
-const projectBufferLayer = {
-  id: 'project-buffer-line',
-  type: 'line',
-  paint: {
-    'line-color': 'rgba(122, 0, 72, 1)',
-    'line-width': 3,
-    'line-dasharray': [
-      0.75,
-      0.75,
-    ],
-  },
-};
+import projectGeomLayers from '../utils/project-geom-layers';
 
 const defaultLayerGroups = {
   'layer-groups': [
@@ -159,11 +122,17 @@ export default class MapFormComponent extends Component {
 
   mapConfiguration = null;
 
-  developmentSiteLayer = developmentSiteLayer
+  @argument
+  developmentSiteLayer = projectGeomLayers.developmentSiteLayer
 
-  projectAreaLayer = projectAreaLayer
+  @argument
+  projectAreaLayer = projectGeomLayers.projectAreaLayer
 
-  projectBufferLayer = projectBufferLayer
+  @argument
+  rezoningAreaIcon = projectGeomLayers.rezoningAreaIcon
+
+  @argument
+  projectBufferLayer = projectGeomLayers.projectBufferLayer
 
   mapInstance = null
 

--- a/app/components/map-form.js
+++ b/app/components/map-form.js
@@ -46,6 +46,7 @@ const projectBufferLayer = {
 
 const defaultLayerGroups = {
   'layer-groups': [
+    { id: 'subway', visible: true },
     {
       id: 'tax-lots',
       visible: true,
@@ -82,7 +83,6 @@ const defaultLayerGroups = {
         },
       ],
     },
-    { id: 'subway', visible: true },
     { id: 'special-purpose-districts', visible: false },
     {
       id: 'citymap',
@@ -95,8 +95,21 @@ const defaultLayerGroups = {
         {}, // citymap-street-not-mapped-line
         { tooltipable: false }, // borough-boundaries
         {}, // citymap-underpass-tunnel-line
-        { tooltipable: false }, // railway-lines
-        {}, // railway-cross-lines
+        {
+          style: {
+            paint: {
+              'line-color': 'rgba(0,0,0,0)',
+            },
+          },
+          tooltipable: false,
+        }, // railway-lines
+        {
+          style: {
+            paint: {
+              'line-color': 'rgba(0,0,0,0)',
+            },
+          },
+        }, // railway-cross-lines
       ],
     },
     { id: 'street-direction-arrows', visible: true },

--- a/app/styles/modules/_m-legend.scss
+++ b/app/styles/modules/_m-legend.scss
@@ -4,17 +4,15 @@
 
 .legend {
   padding-bottom: $global-margin;
-
-  hr {
-    margin: $global-margin 0;
-  }
 }
 .legend-item {
   margin-bottom: rem-calc(4);
 }
 
-.legend-section + .legend-section {
-  margin-top: $global-margin;
+.legend-section {
+  margin-top: rem-calc(10);
+  padding-top: rem-calc(10);
+  border-top: $hr-border;
 }
 
 .legend-section-header {

--- a/app/templates/components/map-form.hbs
+++ b/app/templates/components/map-form.hbs
@@ -56,9 +56,6 @@
                     <div id="north-n" style={{northArrowTransforms.n}}><span class="n" style={{northArrowTransforms.nSpan}}>N</span></div>
                   </div>
                 </div>
-                <div class="cell small-12">
-                  <hr>
-                </div>
               </div>
 
             </div>

--- a/app/templates/projects/edit/map/new.hbs
+++ b/app/templates/projects/edit/map/new.hbs
@@ -1,4 +1,5 @@
 {{#map-form model=model tagName='' as |areaMapForm|}}
+
   <section class="legend-section">
     <h2 class="legend-section-header">Project</h2>
     <div class="grid-x">
@@ -24,6 +25,7 @@
       {{/if}}
     </div>
   </section>
+
   <section class="legend-section">
     <div class="grid-x">
       <div class="cell zoning-section-cell">
@@ -50,6 +52,37 @@
       </div>
     </div>
   </section>
+
+  <section class="legend-section">
+    <h2 class="legend-section-header">Transportation</h2>
+    <div class="grid-x grid-margin-x">
+      <div class="cell shrink">
+        <div class="legend-item">
+          <div class="legend-icon">
+            <span class="fa-layers">
+              {{fa-icon 'long-arrow-alt-left' class="red" transform="right-7 grow-10"}}
+              {{fa-icon 'long-arrow-alt-right' class="red" transform="left-7 grow-10"}}
+              {{fa-icon 'circle' class="black"}}
+              {{fa-icon 'circle' class="white" transform="shrink-3"}}
+            </span>
+          </div>
+          Subway Stop
+        </div>
+      </div>
+      <div class="cell shrink">
+        <div class="legend-item">
+          <div class="legend-icon">
+            <span class="fa-layers">
+              {{fa-icon 'circle' class="black" transform="shrink-6"}}
+              {{fa-icon 'circle' class="white" transform="shrink-10"}}
+            </span>
+          </div>
+          Subway Entrance
+        </div>
+      </div>
+    </div>
+  </section>
+
 {{/map-form}}
 
 {{outlet}}

--- a/app/utils/project-geom-layers.js
+++ b/app/utils/project-geom-layers.js
@@ -1,5 +1,6 @@
 // Development Site
 const developmentSiteLayer = {
+  id: 'development-site-line',
   type: 'line',
   paint: {
     'line-color': 'rgba(237, 18, 18, 1)',
@@ -22,7 +23,12 @@ const developmentSiteIcon = {
 
 // Project Area
 const projectAreaLayer = {
+  id: 'project-area-line',
   type: 'line',
+  layout: {
+    visibility: 'visible',
+    'line-cap': 'round',
+  },
   paint: {
     'line-color': 'rgba(0, 122, 122, 1)',
     'line-width': 2.5,
@@ -68,6 +74,21 @@ const rezoningAreaIcon = {
 };
 
 
+// Project Buffer
+const projectBufferLayer = {
+  id: 'project-buffer-line',
+  type: 'line',
+  paint: {
+    'line-color': 'rgba(122, 0, 72, 1)',
+    'line-width': 3,
+    'line-dasharray': [
+      0.75,
+      0.75,
+    ],
+  },
+};
+
+
 export default {
   developmentSiteLayer,
   developmentSiteIcon,
@@ -75,4 +96,5 @@ export default {
   projectAreaIcon,
   rezoningAreaLayer,
   rezoningAreaIcon,
+  projectBufferLayer,
 };


### PR DESCRIPTION
This PR adds a transportation section to the Area Map legend (closes #136), increases the buffer on the inset map to show borough context (closes #135), nixes the rail lines from citymap which were running under subways, simplifies the legend styles, and consolidates repeated style objects into the geom util. 