### PR TITLE
set mapZoom and mapCenter

### DIFF
--- a/app/components/map-form.js
+++ b/app/components/map-form.js
@@ -290,6 +290,10 @@ export default class MapFormComponent extends Component {
 
     map.setBearing(bearing);
     this.updateBounds();
+    const mapZoom = map.getZoom();
+    this.set('model.mapZoom', mapZoom);
+    const mapCenter = map.getCenter();
+    this.set('model.mapCenter', mapCenter);
   }
 
   @action


### PR DESCRIPTION
This PR saves these properties to the DB, but it doesn't yet utilize them in rendering the map. In order to implement that, one option would be to identify which route is active and then conditionally either fitBounds based on the project geom (for the "new" route) or set the map properties from the model retrieved from the DB ("edit" route).