### PR TITLE
Don't hide form fields, disable them. 

### DIFF
--- a/app/components/draw-control.js
+++ b/app/components/draw-control.js
@@ -62,9 +62,15 @@ export default class DrawControlController extends Component {
   @argument
   resetAction = null
 
+  @argument
+  doneAction = null
+
   selectedZoningFeature = undefined
 
   deleteModalIsOpen = false
+
+  @argument
+  disabled = false
 
   @argument
   developmentSiteIcon = projectGeomLayers.developmentSiteIcon
@@ -100,7 +106,8 @@ export default class DrawControlController extends Component {
     return false;
   }
 
-  @action toggleGeometryEditing(mode) {
+  @action
+  toggleGeometryEditing(mode) {
     this.set('geometryMode', mode);
 
     const geometryMode = this.get('geometryMode');
@@ -118,7 +125,7 @@ export default class DrawControlController extends Component {
       }
 
       map.on('draw.selectionchange', ({ features }) => {
-        if (this.get('isProposedZoningMode') && (features.length === 1)) {
+        if (this.get('isProposedZoningMode') && (features.length === 1) && (!this.get('isDestroyed'))) {
           this.set('selectedZoningFeature', features[0]);
         } else {
           this.set('selectedZoningFeature', null);
@@ -181,14 +188,19 @@ export default class DrawControlController extends Component {
 
     const geometryMode = this.get('geometryMode');
     const isProposedZoningMode = this.get('isProposedZoningMode');
+    const model = this.get('model');
 
     // set geometry depending on mode
-    const model = this.get('model');
     if (isProposedZoningMode) {
       model.set(geometryMode, FeatureCollection);
     } else {
       const { geometry } = FeatureCollection.features[0];
       model.set(geometryMode, geometry);
+    }
+
+    const doneAction = this.get('doneAction');
+    if (doneAction) {
+      this.handleDone();
     }
 
     // breakdown the draw tools
@@ -214,5 +226,10 @@ export default class DrawControlController extends Component {
   resetOverlay() {
     this.set('deleteModalIsOpen', false);
     this.resetAction();
+  }
+
+  @action
+  handleDone() {
+    this.doneAction();
   }
 }

--- a/app/components/project-form.js
+++ b/app/components/project-form.js
@@ -88,6 +88,11 @@ export default class ProjectFormComponent extends Component {
     return [this.get('lat'), this.get('lng')];
   }
 
+  @computed('model.developmentSite')
+  get noDevelopmentSite() {
+    return !this.get('model.developmentSite');
+  }
+
   @computed('selectedLots.features.[]')
   get selectedLotsSource() {
     const selectedLots = this.get('selectedLots');

--- a/app/templates/components/draw-control.hbs
+++ b/app/templates/components/draw-control.hbs
@@ -49,7 +49,7 @@
           (or (eq hasGeom.type 'Polygon') (eq hasGeom.type 'MultiPolygon') isProposedZoningMode) 'gray'
         }}"
         {{action 'toggleGeometryEditing' mode}}
-        disabled={{geometryMode}}
+        disabled={{disabled}}
       >
         {{#if (or (eq hasGeom.type 'Polygon') (eq hasGeom.type 'MultiPolygon') isProposedZoningMode)}}
           {{fa-icon 'pencil-alt'}} Edit
@@ -62,7 +62,7 @@
     {{!-- Delete Button --}}
     {{#if (or (eq hasGeom.type 'Polygon') (eq hasGeom.type 'MultiPolygon'))}}
       <span class="cell shrink geom-delete-container">
-        <button class="dark-gray" style="margin-left:0.875rem;" {{action (mut deleteModalIsOpen) (not deleteModalIsOpen)}}>{{fa-icon 'trash-alt'}}</button>
+        <button class="button small clear no-margin" disabled={{disabled}} {{action (mut deleteModalIsOpen) (not deleteModalIsOpen)}}>{{fa-icon 'trash-alt' class="dark-gray"}}</button>
         <span class="geom-delete-modal {{unless deleteModalIsOpen 'hide'}}">
           <strong class="nowrap">Delete the {{modeDisplayName}}?</strong>
           <span class="grid-x">
@@ -73,7 +73,7 @@
       </span>
     {{else if isProposedZoningMode}}
       <span class="cell shrink geom-delete-container">
-        <button class="dark-gray" style="margin-left:0.875rem;" {{action (mut deleteModalIsOpen) (not deleteModalIsOpen)}}>{{fa-icon 'sync-alt'}}</button>
+        <button class="button small clear no-margin" disabled={{disabled}} {{action (mut deleteModalIsOpen) (not deleteModalIsOpen)}}>{{fa-icon 'sync-alt' class="dark-gray"}}</button>
         <span class="geom-delete-modal {{unless deleteModalIsOpen 'hide'}}">
           <strong class="nowrap">Reset the {{modeDisplayName}}?</strong>
           <span class="grid-x">

--- a/app/templates/components/project-form.hbs
+++ b/app/templates/components/project-form.hbs
@@ -34,58 +34,52 @@
         modeDisplayName='Development Site'
         hasGeom=model.developmentSite
         required=true
+        doneAction=(action 'addProposedZoning')
       }}
 
       {{!-- Project Area --}}
-      {{#if model.developmentSite}}
-        {{menu.draw-control
-          mode='projectArea'
-          modeDisplayName='Project Area'
-          hasGeom=model.projectArea
-        }}
-      {{/if}}
+      {{menu.draw-control
+        mode='projectArea'
+        modeDisplayName='Project Area'
+        hasGeom=model.projectArea
+        disabled=noDevelopmentSite
+      }}
 
-      <hr>
+      {{!-- Proposed Zoning --}}
+      {{menu.draw-control
+        mode='proposedZoning'
+        modeDisplayName='Zoning'
+        hasGeom=model.proposedZoning
+        resetAction=(action 'getClippedZoning')
+        disabled=noDevelopmentSite
+      }}
 
-      {{#if model.proposedZoning}}
-        {{!-- Proposed Zoning --}}
-        {{menu.draw-control
-          mode='proposedZoning'
-          modeDisplayName='Zoning'
-          hasGeom=model.proposedZoning
-          resetAction=getClippedZoning
-        }}
+      {{!-- Proposed Commercial Overlays --}}
+      {{menu.draw-control
+        mode='proposedCommercialOverlays'
+        modeDisplayName='Commercial Overlays'
+        hasGeom=model.proposedCommercialOverlays
+        resetAction=(action 'getClippedCommercialOverlays')
+        disabled=noDevelopmentSite
+      }}
 
-        {{!-- Proposed Commercial Overlays --}}
-        {{menu.draw-control
-          mode='proposedCommercialOverlays'
-          modeDisplayName='Commercial Overlays'
-          hasGeom=model.proposedCommercialOverlays
-          resetAction=getClippedCommercialOverlays
-        }}
+      {{!-- Proposed Special Purpose Districts --}}
+      {{menu.draw-control
+        mode='proposedSpecialPurposeDistricts'
+        modeDisplayName='Special Purpose Districts'
+        hasGeom=model.proposedSpecialPurposeDistricts
+        resetAction=(action 'getClippedSpecialPurposeDistricts')
+        disabled=noDevelopmentSite
+      }}
 
-        {{!-- Proposed Special Purpose Districts --}}
-        {{menu.draw-control
-          mode='proposedSpecialPurposeDistricts'
-          modeDisplayName='Special Purpose Districts'
-          hasGeom=model.proposedSpecialPurposeDistricts
-          resetAction=getClippedSpecialPurposeDistricts
-        }}
+      {{!-- Rezoning Area --}}
+      {{menu.draw-control
+        mode='rezoningArea'
+        modeDisplayName='Rezoning Area'
+        hasGeom=model.rezoningArea
+        disabled=noDevelopmentSite
+      }}
 
-        {{!-- Rezoning Area --}}
-        {{menu.draw-control
-          mode='rezoningArea'
-          modeDisplayName='Rezoning Area'
-          hasGeom=model.rezoningArea
-        }}
-      {{else}}
-        {{!-- TODO Make this dependent on the existence of one or more geometries so we know what area to get zoning polygons for --}}
-        <p class="text-right">
-          <button type="button" class="button expanded small no-margin" disabled={{not model.developmentSite}} onclick={{action 'addProposedZoning'}}>
-            {{fa-icon 'plus'}} Add Proposed Zoning Changes
-          </button>
-        </p>
-      {{/if}}
     {{/project-geometries-menu}}
   {{/if}}
 
@@ -172,7 +166,7 @@
         {{/map.source}}
 
         {{!-- Ad-hoc source and layer for showing zoning --}}
-        {{#if (and model.proposedZoning (not-eq geometryMode 'proposedZoning'))}}
+        {{#if (and model.proposedZoning (not-eq geometryMode 'proposedZoning') (not noDevelopmentSite))}}
           {{#map.source options=(mapbox-geojson-source model.proposedZoning) as |source|}}
             {{source.layer
               layer=projectGeomLayers.proposedZoningLayer
@@ -186,7 +180,7 @@
         {{/if}}
 
         {{!-- Ad-hoc source and layer for showing commercial overlays --}}
-        {{#if (and model.proposedCommercialOverlays (not-eq geometryMode 'proposedCommercialOverlays'))}}
+        {{#if (and model.proposedCommercialOverlays (not-eq geometryMode 'proposedCommercialOverlays') (not noDevelopmentSite))}}
           {{#map.source options=(mapbox-geojson-source model.proposedCommercialOverlays) as |source|}}
             {{source.layer layer=projectGeomLayers.coLayer before='boundary_country'}}
             {{source.layer layer=projectGeomLayers.c11Layer before='boundary_country'}}
@@ -203,7 +197,7 @@
         {{/if}}
 
         {{!-- Ad-hoc source and layer for showing commercial overlays --}}
-        {{#if (and model.proposedSpecialPurposeDistricts (not-eq geometryMode 'proposedSpecialPurposeDistricts'))}}
+        {{#if (and model.proposedSpecialPurposeDistricts (not-eq geometryMode 'proposedSpecialPurposeDistricts') (not noDevelopmentSite))}}
           {{#map.source options=(mapbox-geojson-source model.proposedSpecialPurposeDistricts) as |source|}}
             {{source.layer
               layer=projectGeomLayers.proposedSpecialPurposeDistrictsLayer

--- a/tests/acceptance/user-can-click-three-geom-types-test.js
+++ b/tests/acceptance/user-can-click-three-geom-types-test.js
@@ -6,8 +6,6 @@ import {
 } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import mapboxGlLoaded from '../helpers/mapbox-gl-loaded';
-import mapboxGlDrawReady from '../helpers/mapbox-gl-draw-ready';
-import plotVerticies from '../helpers/plot-verticies';
 
 module('Acceptance | user can click three geom types', function(hooks) {
   setupApplicationTest(hooks);
@@ -18,32 +16,6 @@ module('Acceptance | user can click three geom types', function(hooks) {
     await mapboxGlLoaded();
     await click('.draw-control-development-site');
     await click('.draw-control-cancel');
-
-    assert.equal(currentURL(), '/projects/new');
-  });
-
-  test('Project area button is available only after user draws development site', async function(assert) {
-    await visit('/projects/new');
-
-    await mapboxGlLoaded();
-    await click('.draw-control-development-site');
-    // make sure .draw-control-project-area is not available
-    assert.dom('.draw-control-project-area').doesNotExist();
-
-    await mapboxGlDrawReady();
-
-    await plotVerticies(
-      [
-        [550, 388],
-        [590, 444],
-        [604, 369],
-        [604, 369],
-      ],
-    );
-
-    await click('.draw-control-done');
-
-    await click('.draw-control-project-area');
 
     assert.equal(currentURL(), '/projects/new');
   });


### PR DESCRIPTION
This PR nixes the "+Add Proposed Zoning Changes" button in favor of showing all form fields as disabled and creating the proposed zoning geoms when the dev site is created. 