### PR TITLE
🖨 Print Better

### DIFF
--- a/app/styles/_foundation-print.scss
+++ b/app/styles/_foundation-print.scss
@@ -1,0 +1,86 @@
+// Foundation for Sites by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+/// If `true`, all elements will have transparent backgrounds when printed, to save on ink.
+/// @type Boolean
+/// @group global
+$print-transparent-backgrounds: true !default;
+$print-hrefs: true !default;
+
+// sass-lint:disable-all
+
+@mixin foundation-print-styles {
+  .show-for-print { display: none !important; }
+
+  @media print {
+    * {
+      @if $print-transparent-backgrounds {
+        background: transparent !important;
+      }
+
+      box-shadow: none !important;
+
+      // color: black !important; // Black prints faster: h5bp.com/s
+      text-shadow: none !important;
+    }
+
+    .show-for-print { display: block !important; }
+    .hide-for-print { display: none !important; }
+
+    table.show-for-print { display: table !important; }
+    thead.show-for-print { display: table-header-group !important; }
+    tbody.show-for-print { display: table-row-group !important; }
+    tr.show-for-print { display: table-row !important; }
+    td.show-for-print { display: table-cell !important; }
+    th.show-for-print { display: table-cell !important; }
+
+    // Display the URL of a link after the text
+    a,
+    a:visited { text-decoration: underline;}
+    @if $print-hrefs {
+      a[href]:after { content: ' (' attr(href) ')'; }
+    }
+
+    // Don't display the URL for images or JavaScript/internal links
+    .ir a:after,
+    a[href^='javascript:']:after,
+    a[href^='#']:after { content: ''; }
+
+    // Display what an abbreviation stands for after the text
+    abbr[title]:after { content: ' (' attr(title) ')'; }
+
+    // Prevent page breaks in the middle of a blockquote or preformatted text block
+    pre,
+    blockquote {
+      border: 1px solid $dark-gray;
+      page-break-inside: avoid;
+    }
+
+    // h5bp.com/t
+    thead { display: table-header-group; }
+
+    tr,
+    img { page-break-inside: avoid; }
+
+    img { max-width: 100% !important; }
+
+    @page { margin: 0.5cm; }
+
+    p,
+    h2,
+    h3 {
+      orphans: 3;
+      widows: 3;
+    }
+
+    // Avoid page breaks after a heading
+    h2,
+    h3 { page-break-after: avoid; }
+
+    // Helper to re-allow page breaks in the middle of certain elements (e.g. pre, blockquote, tr)
+    .print-break-inside {
+      page-break-inside: auto;
+    }
+  }
+}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -11,6 +11,8 @@
 // --------------------------------------------------
 @import 'foundation-sites/foundation';
 
+@import 'foundation-print'; // Override Foundation's  foundation-print-styles mixin
+
 @include foundation-global-styles;
 @include foundation-xy-grid-classes;
 //@include foundation-grid;

--- a/app/templates/components/map-form.hbs
+++ b/app/templates/components/map-form.hbs
@@ -1,32 +1,6 @@
 {{#if mapConfiguration}}
   <div class="cell sidebar">
-    <h2 class="header-large">{{model.project.projectName}} {{model.mapTypeLabel}}</h2>
-
-    <hr>
-
-    <h5>Paper Settings</h5>
-    <p>
-      <input type="radio" name="paper-orientation" class="portrait-radio-button" value="portrait" id="paper-orientation--portrait" checked={{eq model.paperOrientation "portrait"}} onclick={{action 'reorientPaper' 'portrait'}}/>
-      <label for="paper-orientation--portrait">Portrait</label>
-      <input type="radio" name="paper-orientation" class="landscape-radio-button" value="landscape" id="paper-orientation--landscape" checked={{eq model.paperOrientation "landscape"}}  onclick={{action 'reorientPaper' 'landscape'}}/>
-      <label for="paper-orientation--landscape">Landscape</label>
-    </p>
-    <p>
-      <input type="radio" name="paper-size" class="tabloid-radio-button" value="tabloid" id="paper-size--tabloid" checked={{eq model.paperSize "tabloid"}} onclick={{action 'scalePaper' 'tabloid'}}/>
-      <label for="paper-size--tabloid">Tabloid</label>
-      <input type="radio" name="paper-size" class="letter-radio-button" value="letter" id="paper-size--letter" checked={{eq model.paperSize "letter"}} onclick={{action  'scalePaper' 'letter'}}/>
-      <label for="paper-size--letter">Letter</label>
-    </p>
-    <hr>
-
-    <h5>Project Area Buffer</h5>
-    <input type="radio" name="buffer-size" checked={{eq model.bufferSize "600"}} id="buffer-size--600" onclick={{action (mut model.bufferSize) '600'}}>
-    <label for="buffer-size--600">600ft</label>
-    <input type="radio" name="buffer-size" checked={{eq model.bufferSize "400"}} id="buffer-size--400" onclick={{action (mut model.bufferSize) '400'}}>
-    <label for="buffer-size--400">400ft</label>
-
-    <p class="text-tiny">Most ULURP area maps should show a buffer of 600 feet around the project area.  CEQR area maps should show a buffer of 400 feet.</p>
-    <hr>
+    <h2 class="header-large">{{model.project.projectName}} <span class="nowrap">{{model.mapTypeLabel}}</span></h2>
 
     <div class="grid-x grid-margin-x">
       <div class="cell auto">
@@ -44,11 +18,40 @@
       </div>
     </div>
 
+    <h5>Paper Settings</h5>
+    <p>
+      <input type="radio" name="paper-orientation" class="portrait-radio-button" value="portrait" id="paper-orientation--portrait" checked={{eq model.paperOrientation "portrait"}} onclick={{action 'reorientPaper' 'portrait'}}/>
+      <label for="paper-orientation--portrait">Portrait</label>
+      <input type="radio" name="paper-orientation" class="landscape-radio-button" value="landscape" id="paper-orientation--landscape" checked={{eq model.paperOrientation "landscape"}}  onclick={{action 'reorientPaper' 'landscape'}}/>
+      <label for="paper-orientation--landscape">Landscape</label>
+    </p>
+    <p>
+      <input type="radio" name="paper-size" class="tabloid-radio-button" value="tabloid" id="paper-size--tabloid" checked={{eq model.paperSize "tabloid"}} onclick={{action 'scalePaper' 'tabloid'}}/>
+      <label for="paper-size--tabloid">Tabloid</label>
+      <input type="radio" name="paper-size" class="letter-radio-button" value="letter" id="paper-size--letter" checked={{eq model.paperSize "letter"}} onclick={{action  'scalePaper' 'letter'}}/>
+      <label for="paper-size--letter">Letter</label>
+    </p>
+
+    <h5>Project Area Buffer</h5>
+    <input type="radio" name="buffer-size" checked={{eq model.bufferSize "600"}} id="buffer-size--600" onclick={{action (mut model.bufferSize) '600'}}>
+    <label for="buffer-size--600">600ft</label>
+    <input type="radio" name="buffer-size" checked={{eq model.bufferSize "400"}} id="buffer-size--400" onclick={{action (mut model.bufferSize) '400'}}>
+    <label for="buffer-size--400">400ft</label>
+
+    <p class="text-tiny">Most ULURP area maps should show a buffer of 600 feet around the project area.  CEQR area maps should show a buffer of 400 feet.</p>
+
     <hr/>
 
     <div class="grid-x grid-margin-x align-middle">
       {{#link-to "projects.show" model.project class="cell shrink button small clear"}}{{fa-icon 'arrow-left'}} Go Back to Project{{/link-to}}
-      <button class="cell auto button project-save-button" type="button" onclick={{action 'saveProject'}}>Save Map</button>
+      <button class="cell auto button green project-save-button" type="button" onclick={{action 'saveProject'}}>Save Map</button>
+    </div>
+
+    <hr/>
+
+    <div class="grid-x grid-margin-x">
+      <p class="cell shrink medium-5"><button class="button gray expanded" type="button" onClick=print()>{{fa-icon 'print'}} Print</button></p>
+      <p class="cell auto text-tiny dark-gray">Make sure your system's print settings enable printing background graphics and that the paper size and orientation match your map.</p>
     </div>
 
   </div>


### PR DESCRIPTION
This PR adds a print button to the Area Map with some short instructions. 

It also includes a copy of Foundation's `_foundation-print.scss` file, which includes a mixin that has `color: black !important` for print. In order to nix this 1 rule, I'm including our own version of the whole file. (Gross.)