### PR TITLE
212 inputs

### DIFF
--- a/app/controllers/projects/edit/geometry-edit.js
+++ b/app/controllers/projects/edit/geometry-edit.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
 
 export default class GeometryEditController extends Controller {
-  queryParams = ['mode'];
+  queryParams = ['type', 'mode'];
 }

--- a/app/controllers/projects/edit/steps/rezoning.js
+++ b/app/controllers/projects/edit/steps/rezoning.js
@@ -1,0 +1,11 @@
+import Controller from '@ember/controller';
+import { computed } from '@ember-decorators/object';
+
+export default class RezoningController extends Controller {
+  @computed('model.needRezoning', 'model.needUnderlyingZoning', 'model.needCommercialOverlay', 'model.needSpecialDistrict')
+  get hasAnsweredAll() {
+    if ((this.get('model.needRezoning') === true) && (this.get('model.needUnderlyingZoning') != null) && (this.get('model.needCommercialOverlay') != null) && (this.get('model.needSpecialDistrict') != null)) return true;
+
+    return false;
+  }
+}

--- a/app/controllers/projects/edit/steps/rezoning.js
+++ b/app/controllers/projects/edit/steps/rezoning.js
@@ -8,4 +8,13 @@ export default class RezoningController extends Controller {
 
     return false;
   }
+
+  @computed('model.needRezoning', 'model.needUnderlyingZoning', 'model.needCommercialOverlay', 'model.needSpecialDistrict')
+  get firstGeomType() {
+    if ((this.get('model.needRezoning') === true) && (this.get('model.needUnderlyingZoning') === true)) return 'rezoning-underlying';
+    if ((this.get('model.needRezoning') === true) && (this.get('model.needCommercialOverlay') === true)) return 'rezoning-commercial';
+    if ((this.get('model.needRezoning') === true) && (this.get('model.model.needSpecialDistrict') === true)) return 'rezoning-special';
+
+    return false;
+  }
 }

--- a/app/templates/projects/edit/steps/development-site.hbs
+++ b/app/templates/projects/edit/steps/development-site.hbs
@@ -3,10 +3,10 @@
   <p>The Development Site refers to the zoning lot(s) to be improved by the specific development(s) that the land use actions would facilitate.</p>
   <p>To create a Development Site, you can either:</p>
 
-  {{link-to 'Select Lots' 'projects.edit.geometry-edit' model.id (query-params mode='lots')
+  {{link-to 'Select Lots' 'projects.edit.geometry-edit' model.id (query-params mode='lots' type='development-site')
     tagName='span'
     class='button'}}
 
-  {{link-to 'Draw Manually' 'projects.edit.geometry-edit' model.id (query-params mode='draw')
+  {{link-to 'Draw Manually' 'projects.edit.geometry-edit' model.id (query-params mode='draw' type='development-site')
     tagName='span'
     class='button'}}

--- a/app/templates/projects/edit/steps/project-area.hbs
+++ b/app/templates/projects/edit/steps/project-area.hbs
@@ -1,2 +1,20 @@
-Placeholder for page asking if you need to define a project area
+<p>Placeholder for page asking if you need to define a project area</p>
+
+<p>Do you need a project area?</p>
+<p>
+    <input type="radio" name="project-area-question" checked={{eq model.needProjectArea true}} id="project-area-question--yes" onclick={{action (mut model.needProjectArea) true}}>
+    <label for="project-area-question--yes">Yes</label>
+    <input type="radio" name="project-area-question" checked={{eq model.needProjectArea false}} id="project-area-question--no" onclick={{action (mut model.needProjectArea) false}}>
+    <label for="buffer-size--no">No</label>
+</p>
+<br>
+
+{{link-to 'Select Lots' 'projects.edit.geometry-edit' model.id (query-params mode='lots' type='project-area')
+tagName='span'
+class='button'}}
+
+{{link-to 'Draw Manually' 'projects.edit.geometry-edit' model.id (query-params mode='draw' type='project-area')
+tagName='span'
+class='button'}}
+
 {{outlet}}

--- a/app/templates/projects/edit/steps/project-area.hbs
+++ b/app/templates/projects/edit/steps/project-area.hbs
@@ -2,19 +2,21 @@
 
 <p>Do you need a project area?</p>
 <p>
-    <input type="radio" name="project-area-question" checked={{eq model.needProjectArea true}} id="project-area-question--yes" onclick={{action (mut model.needProjectArea) true}}>
-    <label for="project-area-question--yes">Yes</label>
-    <input type="radio" name="project-area-question" checked={{eq model.needProjectArea false}} id="project-area-question--no" onclick={{action (mut model.needProjectArea) false}}>
-    <label for="buffer-size--no">No</label>
+  <input type="radio" name="project-area-question" checked={{eq model.needProjectArea true}} id="project-area-question--yes" onclick={{action (mut model.needProjectArea) true}}>
+  <label for="project-area-question--yes">Yes</label>
+  <input type="radio" name="project-area-question" checked={{eq model.needProjectArea false}} id="project-area-question--no" onclick={{action (mut model.needProjectArea) false}}>
+  <label for="buffer-size--no">No</label>
 </p>
 <br>
 
-{{link-to 'Select Lots' 'projects.edit.geometry-edit' model.id (query-params mode='lots' type='project-area')
-tagName='span'
-class='button'}}
+{{#if (eq model.needProjectArea true)}}
+	{{link-to 'Select Lots' 'projects.edit.geometry-edit' model.id (query-params mode='lots' type='project-area')
+	tagName='span'
+	class='button'}}
 
-{{link-to 'Draw Manually' 'projects.edit.geometry-edit' model.id (query-params mode='draw' type='project-area')
-tagName='span'
-class='button'}}
+	{{link-to 'Draw Manually' 'projects.edit.geometry-edit' model.id (query-params mode='draw' type='project-area')
+	tagName='span'
+	class='button'}}
+{{/if}}
 
 {{outlet}}

--- a/app/templates/projects/edit/steps/rezoning.hbs
+++ b/app/templates/projects/edit/steps/rezoning.hbs
@@ -2,41 +2,44 @@
 
 <p>Do you need rezoning?</p>
 <p>
-    <input type="radio" name="rezoning-question" checked={{eq model.needRezoning true}} id="rezoning-question--yes" onclick={{action (mut model.needRezoning) true}}>
-    <label for="rezoning-question--yes">Yes</label>
-    <input type="radio" name="rezoning-question" checked={{eq model.needRezoning false}} id="rezoning-question--no" onclick={{action (mut model.needRezoning) false}}>
-    <label for="rezoning-question--no">No</label>
+  <input type="radio" name="rezoning-question" checked={{eq model.needRezoning true}} id="rezoning-question--yes" onclick={{action (mut model.needRezoning) true}}>
+  <label for="rezoning-question--yes">Yes</label>
+  <input type="radio" name="rezoning-question" checked={{eq model.needRezoning false}} id="rezoning-question--no" onclick={{action (mut model.needRezoning) false}}>
+  <label for="rezoning-question--no">No</label>
 </p>
 <br>
 
 {{#if (eq model.needRezoning true)}}
-<p>For each of the following, please indicate if you are proposing changes:</p>
-<p>Underlying Zoning<br>
+{{!-- Note: We will want form validation here that requires them to say yes to at least one of these three --}}
+	<p>For each of the following, please indicate if you are proposing changes:</p>
+	<p>Underlying Zoning<br>
     <input type="radio" name="underlying-question" checked={{eq model.needUnderlyingZoning true}} id="underlying-question--yes" onclick={{action (mut model.needUnderlyingZoning) true}}>
     <label for="underlying-question--yes">Yes</label>
     <input type="radio" name="underlying-question" checked={{eq model.needUnderlyingZoning false}} id="underlying-question--no" onclick={{action (mut model.needUnderlyingZoning) false}}>
     <label for="underlying-question--no">No</label>
-</p>
-<p>Commercial Overlays<br>
+	</p>
+	<p>Commercial Overlays<br>
     <input type="radio" name="commercial-question" checked={{eq model.needCommercialOverlay true}} id="commercial-question--yes" onclick={{action (mut model.needCommercialOverlay) true}}>
     <label for="commercial-question--yes">Yes</label>
     <input type="radio" name="commercial-question" checked={{eq model.needCommercialOverlay false}} id="commercial-question--no" onclick={{action (mut model.needCommercialOverlay) false}}>
     <label for="commercial-question--no">No</label>
-</p>
-<p>Special Purpose Districts<br>
+	</p>
+	<p>Special Purpose Districts<br>
     <input type="radio" name="special-question" checked={{eq model.needSpecialDistrict true}} id="special-question--yes" onclick={{action (mut model.needSpecialDistrict) true}}>
     <label for="special-question--yes">Yes</label>
     <input type="radio" name="special-question" checked={{eq model.needSpecialDistrict false}} id="special-question--no" onclick={{action (mut model.needSpecialDistrict) false}}>
     <label for="special-question--no">No</label>
-</p>
+	</p>
 {{/if}}
 
-{{link-to 'Select Lots' 'projects.edit.geometry-edit' model.id (query-params mode='lots' type='development-site')
-tagName='span'
-class='button'}}
+{{#if hasAnsweredAll}}
+	{{link-to 'Select Lots' 'projects.edit.geometry-edit' model.id (query-params mode='lots' type='development-site')
+	tagName='span'
+	class='button'}}
 
-{{link-to 'Draw Manually' 'projects.edit.geometry-edit' model.id (query-params mode='draw' type='development-site')
-tagName='span'
-class='button'}}
+	{{link-to 'Draw Manually' 'projects.edit.geometry-edit' model.id (query-params mode='draw' type='development-site')
+	tagName='span'
+	class='button'}}
+{{/if}}
 
 {{outlet}}

--- a/app/templates/projects/edit/steps/rezoning.hbs
+++ b/app/templates/projects/edit/steps/rezoning.hbs
@@ -1,2 +1,42 @@
-Placeholder for page asking if you are proposing rezoning
+<p>Placeholder for page asking if you are proposing rezoning</p>
+
+<p>Do you need rezoning?</p>
+<p>
+    <input type="radio" name="rezoning-question" checked={{eq model.needRezoning true}} id="rezoning-question--yes" onclick={{action (mut model.needRezoning) true}}>
+    <label for="rezoning-question--yes">Yes</label>
+    <input type="radio" name="rezoning-question" checked={{eq model.needRezoning false}} id="rezoning-question--no" onclick={{action (mut model.needRezoning) false}}>
+    <label for="rezoning-question--no">No</label>
+</p>
+<br>
+
+{{#if (eq model.needRezoning true)}}
+<p>For each of the following, please indicate if you are proposing changes:</p>
+<p>Underlying Zoning<br>
+    <input type="radio" name="underlying-question" checked={{eq model.needUnderlyingZoning true}} id="underlying-question--yes" onclick={{action (mut model.needUnderlyingZoning) true}}>
+    <label for="underlying-question--yes">Yes</label>
+    <input type="radio" name="underlying-question" checked={{eq model.needUnderlyingZoning false}} id="underlying-question--no" onclick={{action (mut model.needUnderlyingZoning) false}}>
+    <label for="underlying-question--no">No</label>
+</p>
+<p>Commercial Overlays<br>
+    <input type="radio" name="commercial-question" checked={{eq model.needCommercialOverlay true}} id="commercial-question--yes" onclick={{action (mut model.needCommercialOverlay) true}}>
+    <label for="commercial-question--yes">Yes</label>
+    <input type="radio" name="commercial-question" checked={{eq model.needCommercialOverlay false}} id="commercial-question--no" onclick={{action (mut model.needCommercialOverlay) false}}>
+    <label for="commercial-question--no">No</label>
+</p>
+<p>Special Purpose Districts<br>
+    <input type="radio" name="special-question" checked={{eq model.needSpecialDistrict true}} id="special-question--yes" onclick={{action (mut model.needSpecialDistrict) true}}>
+    <label for="special-question--yes">Yes</label>
+    <input type="radio" name="special-question" checked={{eq model.needSpecialDistrict false}} id="special-question--no" onclick={{action (mut model.needSpecialDistrict) false}}>
+    <label for="special-question--no">No</label>
+</p>
+{{/if}}
+
+{{link-to 'Select Lots' 'projects.edit.geometry-edit' model.id (query-params mode='lots' type='development-site')
+tagName='span'
+class='button'}}
+
+{{link-to 'Draw Manually' 'projects.edit.geometry-edit' model.id (query-params mode='draw' type='development-site')
+tagName='span'
+class='button'}}
+
 {{outlet}}

--- a/app/templates/projects/edit/steps/rezoning.hbs
+++ b/app/templates/projects/edit/steps/rezoning.hbs
@@ -33,11 +33,12 @@
 {{/if}}
 
 {{#if hasAnsweredAll}}
-	{{link-to 'Select Lots' 'projects.edit.geometry-edit' model.id (query-params mode='lots' type='{{get model.firstGeomType}}')
+  <p>{{firstGeomType}}</p>
+	{{link-to 'Select Lots' 'projects.edit.geometry-edit' model.id (query-params mode='lots' type=firstGeomType)
 	tagName='span'
 	class='button'}}
 
-	{{link-to 'Draw Manually' 'projects.edit.geometry-edit' model.id (query-params mode='draw' type='{{get model.firstGeomType}}')
+	{{link-to 'Draw Manually' 'projects.edit.geometry-edit' model.id (query-params mode='draw' type=firstGeomType)
 	tagName='span'
 	class='button'}}
 {{/if}}

--- a/app/templates/projects/edit/steps/rezoning.hbs
+++ b/app/templates/projects/edit/steps/rezoning.hbs
@@ -33,11 +33,11 @@
 {{/if}}
 
 {{#if hasAnsweredAll}}
-	{{link-to 'Select Lots' 'projects.edit.geometry-edit' model.id (query-params mode='lots' type='development-site')
+	{{link-to 'Select Lots' 'projects.edit.geometry-edit' model.id (query-params mode='lots' type='{{get model.firstGeomType}}')
 	tagName='span'
 	class='button'}}
 
-	{{link-to 'Draw Manually' 'projects.edit.geometry-edit' model.id (query-params mode='draw' type='development-site')
+	{{link-to 'Draw Manually' 'projects.edit.geometry-edit' model.id (query-params mode='draw' type='{{get model.firstGeomType}}')
 	tagName='span'
 	class='button'}}
 {{/if}}

--- a/app/templates/projects/edit/steps/rezoning.hbs
+++ b/app/templates/projects/edit/steps/rezoning.hbs
@@ -33,7 +33,6 @@
 {{/if}}
 
 {{#if hasAnsweredAll}}
-  <p>{{firstGeomType}}</p>
 	{{link-to 'Select Lots' 'projects.edit.geometry-edit' model.id (query-params mode='lots' type=firstGeomType)
 	tagName='span'
 	class='button'}}

--- a/tests/unit/controllers/projects/edit/steps/rezoning-test.js
+++ b/tests/unit/controllers/projects/edit/steps/rezoning-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | projects/edit/steps/rezoning', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let controller = this.owner.lookup('controller:projects/edit/steps/rezoning');
+    assert.ok(controller);
+  });
+});


### PR DESCRIPTION
This PR populates the templates with inputs that feed into the model and are used for routing and query params.

**Changes proposed:**
- Adds yes/no radio buttons to the project-area and rezoning templates that populate all the required boolean fields in the project model
- Adds `type` parameter to the geometry-edit controller
- Adds controller for rezoning template that
  - identifies if the user has answered all the required rezoning questions before allowing them to navigate to the geometry-edit route via the buttons
  - identifies which geometry should be fed in as the `type` parameter first based on which rezoning geoms the user said they need.

@allthesignals I don't think this impacts/overlaps with any of your work, but want to make sure you're aware and agree with these changes.

Closes #212