### PR TITLE
currentStep = project-creation

### DIFF
--- a/app/models/project.js
+++ b/app/models/project.js
@@ -89,7 +89,7 @@ export default class extends Model {
     const needUnderlyingZoning = this.get('needUnderlyingZoning');
     const needCommercialOverlay = this.get('needCommercialOverlay');
     const needSpecialDistrict = this.get('needSpecialDistrict');
-    if (projectName == null) {
+    if (projectName == null || projectName === '') {
       return { label: 'project-creation', route: 'projects.new' };
     } if (developmentSite == null) {
       return { label: 'development-site', route: 'projects.edit.steps.development-site' };

--- a/app/templates/components/project-form.hbs
+++ b/app/templates/components/project-form.hbs
@@ -63,7 +63,7 @@
     <button
       type="button"
       class="button large expanded project-save-button"
-      disabled={{eq model.currentStep.label 'project-creation'}} 
+      disabled={{eq model.currentStep.label 'project-creation'}}
       onclick={{action 'save' model}}
     >
       Create New Project


### PR DESCRIPTION
This PR fixes the logic for the first step. It was not getting set to `project-creation` if the user deleted the `projectName`. The new condition checks if it's `null` OR an empty string so that the "Create…" button is disabled unless there's a project name. 