### PR TITLE
zoom closer when user searches address

### DIFF
--- a/app/components/project-form.js
+++ b/app/components/project-form.js
@@ -117,7 +117,7 @@ export default class ProjectFormComponent extends Component {
     const { mapInstance: map } = this;
 
     this.set('geocodedFeature', { type: 'geojson', data: geometry });
-    map.flyTo({ center: coordinates, zoom: 16 });
+    map.flyTo({ center: coordinates, zoom: 18 });
   }
 
   @action


### PR DESCRIPTION
Super simple fix--just increasing the zoom from 16 to 18 for address search. User can see tax lots well at this zoom level. 

Closes #234 