### PR TITLE
[WIP] Automated rezoning area

### DIFF
--- a/app/components/draw-control.js
+++ b/app/components/draw-control.js
@@ -134,9 +134,6 @@ export default class DrawControlController extends Component {
           this.set('selectedZoningFeature', null);
         }
       });
-
-      // temporary
-      map.on('draw.update', (e) => { console.log(e); })
     } else {
       // breakdown all the drawing mode stuff
       draw.trash();

--- a/app/components/draw-control.js
+++ b/app/components/draw-control.js
@@ -134,6 +134,9 @@ export default class DrawControlController extends Component {
           this.set('selectedZoningFeature', null);
         }
       });
+
+      // temporary
+      map.on('draw.update', (e) => { console.log(e); })
     } else {
       // breakdown all the drawing mode stuff
       draw.trash();

--- a/app/components/project-form.js
+++ b/app/components/project-form.js
@@ -315,49 +315,42 @@ export default class ProjectFormComponent extends Component {
     const currentZoning = this.get('model.currentZoning');
     const proposedZoning = this.get('model.proposedZoning');
 
+    // create an empty FeatureCollection to hold the difference sections
     const differenceFC = {
       type: 'FeatureCollection',
       features: [],
-    }
+    };
     // flag differences
     proposedZoning.features.forEach((feature) => {
-      const { id, geometry } = feature;
-      const correspondingCurrentZoningFeature = currentZoning.features.filter(d => d.id === id)[0]
-      console.log('CORRESPONDING FEATURE', correspondingCurrentZoningFeature)
+      const { id } = feature;
+      const correspondingCurrentZoningFeature = currentZoning.features.filter(d => d.id === id)[0];
+
       // if feature exists in currentZoning, compare the geometries
       if (correspondingCurrentZoningFeature) {
-        console.log(`${id} exists in current Zoning`)
-        console.log(JSON.stringify(geometry), JSON.stringify(correspondingCurrentZoningFeature.geometry))
-
-        const difference = turfDifference(correspondingCurrentZoningFeature, feature)
+        // get the difference
+        const difference = turfDifference(correspondingCurrentZoningFeature, feature);
         if (difference) differenceFC.features.push(difference);
 
-        const inverseDifference = turfDifference(feature, correspondingCurrentZoningFeature)
-        if (difference) differenceFC.features.push(difference);
-
+        // get the inverse difference (reverse the order of the polygons)
+        const inverseDifference = turfDifference(feature, correspondingCurrentZoningFeature);
+        if (inverseDifference) differenceFC.features.push(inverseDifference);
       } else {
-        console.log(`${id} DOES NOT exist in current Zoning`)
         differenceFC.features.push(feature);
       }
     });
 
-    console.log(differenceFC);
-
     // union together all difference features
     if (differenceFC.features.length > 0) {
       const differenceUnion = differenceFC.features.reduce((union, { geometry }) => {
-
         if (union === null) {
           union = geometry;
         } else {
           union = turfUnion(union, geometry);
         }
 
-
         return union;
       }, null);
-      console.log(JSON.stringify(differenceUnion))
-      this.set('model.rezoningArea', differenceUnion)
+      this.set('model.rezoningArea', differenceUnion);
     }
   }
 }

--- a/app/components/project-form.js
+++ b/app/components/project-form.js
@@ -7,7 +7,7 @@ import { tagName } from '@ember-decorators/component';
 import carto from 'cartobox-promises-utility/utils/carto';
 import turfDifference from '@turf/difference';
 import turfUnion from '@turf/union';
-
+import turfBuffer from '@turf/buffer';
 
 import projectGeomLayers from '../utils/project-geom-layers';
 
@@ -348,7 +348,8 @@ export default class ProjectFormComponent extends Component {
           union = turfUnion(union, geometry);
         }
 
-        return union;
+        const buffered = turfBuffer(union, -0.0005);
+        return buffered;
       }, null);
       this.set('model.rezoningArea', differenceUnion);
     }

--- a/app/components/project-form.js
+++ b/app/components/project-form.js
@@ -328,14 +328,13 @@ export default class ProjectFormComponent extends Component {
       if (correspondingCurrentZoningFeature) {
         console.log(`${id} exists in current Zoning`)
         console.log(JSON.stringify(geometry), JSON.stringify(correspondingCurrentZoningFeature.geometry))
-        const difference = turfDifference(correspondingCurrentZoningFeature, feature)
-        console.log(difference)
-        if (difference) {
 
-          console.log(geometry, correspondingCurrentZoningFeature.geometry)
-          console.log(difference)
-          differenceFC.features.push(difference);
-        }
+        const difference = turfDifference(correspondingCurrentZoningFeature, feature)
+        if (difference) differenceFC.features.push(difference);
+
+        const inverseDifference = turfDifference(feature, correspondingCurrentZoningFeature)
+        if (difference) differenceFC.features.push(difference);
+
       } else {
         console.log(`${id} DOES NOT exist in current Zoning`)
         differenceFC.features.push(feature);
@@ -358,6 +357,7 @@ export default class ProjectFormComponent extends Component {
         return union;
       }, null);
       console.log(JSON.stringify(differenceUnion))
+      this.set('model.rezoningArea', differenceUnion)
     }
   }
 }

--- a/app/models/project.js
+++ b/app/models/project.js
@@ -34,9 +34,15 @@ export default class extends Model {
 
   @attr() rezoningArea
 
+  @attr() currentZoning
+
   @attr() proposedZoning
 
+  @attr() currentCommercialOverlays
+
   @attr() proposedCommercialOverlays
+
+  @attr() currentSpecialPurposeDistricts
 
   @attr() proposedSpecialPurposeDistricts
 

--- a/app/templates/components/project-form.hbs
+++ b/app/templates/components/project-form.hbs
@@ -63,6 +63,7 @@
         hasGeom=model.proposedZoning
         resetAction=(action 'getClippedZoning')
         disabled=noDevelopmentSite
+        doneAction=(action 'calculateRezoningArea')
       }}
 
       {{!-- Proposed Commercial Overlays --}}

--- a/app/utils/project-geom-layers.js
+++ b/app/utils/project-geom-layers.js
@@ -53,6 +53,7 @@ const rezoningAreaLayer = {
   paint: {
     'line-color': 'rgba(0, 0, 0, 1)',
     'line-width': 9,
+    'line-offset': -12,
     'line-dasharray': [0, 2],
   },
   layout: {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@turf/bbox": "^6.0.1",
     "@turf/buffer": "^5.1.5",
     "@turf/centroid": "^6.0.2",
+    "@turf/difference": "^6.0.2",
     "@turf/simplify": "^5.1.5",
     "@turf/union": "^6.0.3",
     "babel-plugin-transform-object-rest-spread": "6.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -457,6 +457,13 @@
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
 
+"@turf/area@6.x":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@turf/area/-/area-6.0.1.tgz#50ed63c70ef2bdb72952384f1594319d94f3b051"
+  dependencies:
+    "@turf/helpers" "6.x"
+    "@turf/meta" "6.x"
+
 "@turf/bbox@^5.1.5":
   version "5.1.5"
   resolved "https://registry.yarnpkg.com/@turf/bbox/-/bbox-5.1.5.tgz#3051df514ad4c50f4a4f9b8a2d15fd8b6840eda3"
@@ -509,6 +516,16 @@
   resolved "https://registry.yarnpkg.com/@turf/clone/-/clone-5.1.5.tgz#253e8d35477181976e33adfab50a0f02a7f0e367"
   dependencies:
     "@turf/helpers" "^5.1.5"
+
+"@turf/difference@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@turf/difference/-/difference-6.0.2.tgz#dd20c0e2301ba6c22019e38a36eea3975205a77f"
+  dependencies:
+    "@turf/area" "6.x"
+    "@turf/helpers" "6.x"
+    "@turf/invariant" "6.x"
+    "@turf/meta" "6.x"
+    martinez-polygon-clipping "^0.4.3"
 
 "@turf/helpers@6.x":
   version "6.1.4"


### PR DESCRIPTION
At the time of opening this PR, I have logic working to automatically draw the rezoning area when the user completes the editing of zoning.

How it works:
- When the user draws the development site, we grab a buffered clipping of existing zoning from the backend as a geoJson featurecollection of polygons.
- We used to only store this once, but now we store it in two properties on the model: currentZoning and proposedZoning.
- When the user edits zoning via the UI, we store their changes as proposedZoning.
- The new code in this branch will compare each feature in the new proposedZoning with its corresponding feature in the currentZoning using turf.difference()
- If there is a geometric difference, the difference gets pushed into a difference featurecollection.
- The fragments of difference in the featurecollection are unioned together, and this union is saved to the model as `rezoningArea`, and drawn on the map as a dotted line.
