### PR TITLE
change the label for tax-lots (numfloors to lot)

### DIFF
--- a/app/components/map-form.js
+++ b/app/components/map-form.js
@@ -106,7 +106,7 @@ const defaultLayerGroups = {
         {},
         {
           style: {
-            layout: { 'text-field': '{numfloors}' },
+            layout: { 'text-field': '{lot}' },
             paint: { 'text-color': 'rgba(33, 35, 38, 1)' },
           },
         },


### PR DESCRIPTION
I made this change a while ago but it got lost I think when we refactored. `lot` number should show up as the label on the tax lot layer instead of `numfloors`