### PR TITLE
Create additional tests; undo button

### DIFF
--- a/app/components/project-geometries.js
+++ b/app/components/project-geometries.js
@@ -41,6 +41,11 @@ export default class ProjectGeometryEditComponent extends Component {
   }
 
   @action
+  rollbackChanges() {
+    this.get('model').rollbackAttributes();
+  }
+
+  @action
   handleMapLoad(map) {
     this.set('mapInstance', map);
     window.map = map;

--- a/app/components/project-geometries/modes/lots.js
+++ b/app/components/project-geometries/modes/lots.js
@@ -49,9 +49,9 @@ export default class LotsComponent extends Component {
     return this.get('store').peekRecord('layer-group', 'tax-lots');
   }
 
-  @computed('selectedLots.features.[]')
+  @computed('geometricProperty.features.@each.geometry')
   get selectedLotsSource() {
-    const selectedLots = this.get('selectedLots');
+    const selectedLots = this.get('geometricProperty');
     return {
       type: 'geojson',
       data: selectedLots,

--- a/app/models/project.js
+++ b/app/models/project.js
@@ -22,25 +22,6 @@ import config from 'labs-applicant-maps/config/environment';
 const { mapTypes } = config;
 const { Model } = DS;
 
-const questionFields = [
-  'needProjectArea',
-  'needRezoning',
-  'needUnderlyingZoning',
-  'needCommercialOverlay',
-  'needSpecialDistrict',
-];
-
-const fieldsForCurrentStep = [
-  'developmentSite',
-  'projectName',
-  'projectArea',
-  'rezoningArea',
-  'underlyingZoning',
-  'commercialOverlays',
-  'specialPurposeDistricts',
-  ...questionFields,
-];
-
 const EmptyFeatureCollection = {
   type: 'FeatureCollection',
   features: [{
@@ -110,7 +91,7 @@ export const projectProcedure = [
     },
     conditions: {
       needRezoning: hasAnswered,
-      needUnderlyingZoning: requiredIf('needRezoning', hasFilledOut),
+      needUnderlyingZoning: requiredIf('needRezoning', hasAnswered),
       needCommercialOverlay: requiredIf('needRezoning', hasAnswered),
       needSpecialDistrict: requiredIf('needRezoning', hasAnswered),
     },
@@ -162,6 +143,9 @@ export const projectProcedure = [
     },
   },
 ];
+
+const procedureKeys = projectProcedure
+  .reduce((acc, { conditions }) => acc.concat(conditions ? Object.keys(conditions) : []), []);
 
 export default class extends Model {
   @hasMany('area-map', { async: false }) areaMaps;
@@ -260,7 +244,7 @@ export default class extends Model {
 
   // ******** COMPUTING THE CURRENT STEP FOR ROUTING ********
 
-  @computed(...fieldsForCurrentStep)
+  @computed(...procedureKeys)
   get currentStep() {
     const { routing } = wizard(projectProcedure, this);
     return routing;

--- a/app/models/project.js
+++ b/app/models/project.js
@@ -246,8 +246,7 @@ export default class extends Model {
 
   @computed(...procedureKeys)
   get currentStep() {
-    const { routing } = wizard(projectProcedure, this);
-    return routing;
+    return wizard(projectProcedure, this);
   }
 
   @computed('currentStep')

--- a/app/routes/projects/show.js
+++ b/app/routes/projects/show.js
@@ -15,7 +15,7 @@ export default class ProjectsShowRoute extends Route {
 
   afterModel(model) {
     // here we check which step we're on so that we can route
-    const { route, mode, type } = model.get('currentStep');
+    const { routing: { route, mode, type } } = model.get('currentStep');
 
     // has the user completed the steps? if not, transition to that step.
     if (model.get('currentStep') !== 'complete') {

--- a/app/templates/components/project-form.hbs
+++ b/app/templates/components/project-form.hbs
@@ -10,6 +10,7 @@
     </div>
     <div class="small-9 cell">
       {{input
+        data-test-new-project-project-name
         type="text"
         value=model.projectName
         id="project-name-field"
@@ -59,8 +60,9 @@
   <button
     type="button"
     class="button large expanded project-save-button"
-    disabled={{eq model.currentStep.label 'project-creation'}}
+    disabled={{eq model.currentStep.step 'project-creation'}}
     onclick={{action 'save' model}}
+    data-test-create-new-project
   >
     Create New Project
   </button>

--- a/app/templates/components/project-geometries.hbs
+++ b/app/templates/components/project-geometries.hbs
@@ -38,6 +38,14 @@
         mode=mode
         map=map}}
 
+      {{#ember-wormhole to='geometry-type-save-box'}}
+        <button class="button smal gray expanded" 
+          disabled={{not model.hasDirtyAttributes}}
+          onclick={{action 'rollbackChanges'}}
+        >
+          Undo
+        </button>
+      {{/ember-wormhole}}
     {{/labs-map}}
   {{/project-geometries/layer-groups}}
 </div>

--- a/app/templates/components/project-geometries.hbs
+++ b/app/templates/components/project-geometries.hbs
@@ -21,7 +21,6 @@
       mapLoaded=(action handleMapLoad) as |map|}}
 
       {{search-handler map=map}}
-
       {{!-- labs-layers (includes tax-lots layer) --}}
       {{#map.labs-layers
         layerGroups=projectMapForm.model.layerGroups

--- a/app/templates/components/project-geometries/commercial-overlays.hbs
+++ b/app/templates/components/project-geometries/commercial-overlays.hbs
@@ -5,6 +5,7 @@
     geometricProperty=model.commercialOverlays as |selection|
   }}
     {{#selection.button
+      enabled=model.hasDirtyAttributes
       handleClick=(action 'save')}}
       Save Commercial Overlays
     {{/selection.button}}

--- a/app/templates/components/project-geometries/development-site.hbs
+++ b/app/templates/components/project-geometries/development-site.hbs
@@ -4,6 +4,7 @@
   geometricProperty=model.developmentSite as |selection|
 }}
   {{#selection.button
+    enabled=model.hasDirtyAttributes
     handleClick=(action 'save')}}
     Save Development Site
   {{/selection.button}}

--- a/app/templates/components/project-geometries/draw-lots-to-union.hbs
+++ b/app/templates/components/project-geometries/draw-lots-to-union.hbs
@@ -8,10 +8,12 @@
     {{yield (hash
       finalGeometry=finalGeometry 
       button=(component 'project-geometries/draw-lots-to-union/button'
+        data-test-project-geometry-save=true
         enabled=isReady
         finalGeometry=finalGeometry))}}
   {{else}}
     {{project-geometries/draw-lots-to-union/button
+      data-test-project-geometry-save=true
       enabled=isReady
       finalGeometry=finalGeometry
     }}

--- a/app/templates/components/project-geometries/project-area.hbs
+++ b/app/templates/components/project-geometries/project-area.hbs
@@ -4,6 +4,7 @@
   geometricProperty=model.projectArea as |selection|
 }}
   {{#selection.button
+    enabled=model.hasDirtyAttributes
     handleClick=(action 'save')}}
     Save Project Area
   {{/selection.button}}

--- a/app/templates/components/project-geometries/special-purpose-districts.hbs
+++ b/app/templates/components/project-geometries/special-purpose-districts.hbs
@@ -5,6 +5,7 @@
     geometricProperty=model.specialPurposeDistricts as |selection|
   }}
     {{#selection.button
+      enabled=model.hasDirtyAttributes
       handleClick=(action 'save')}}
       Save Special Districts
     {{/selection.button}}

--- a/app/templates/components/project-geometries/underlying-zoning.hbs
+++ b/app/templates/components/project-geometries/underlying-zoning.hbs
@@ -5,6 +5,7 @@
     geometricProperty=model.underlyingZoning as |selection|
   }}
     {{#selection.button
+      enabled=model.hasDirtyAttributes
       handleClick=(action 'save')}}
       Save Zoning District
     {{/selection.button}}

--- a/tests/integration/components/project-form-test.js
+++ b/tests/integration/components/project-form-test.js
@@ -1,17 +1,22 @@
-import { module, skip } from 'qunit';
+import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, fillIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { run } from '@ember/runloop';
 
 module('Integration | Component | project-form', function(hooks) {
   setupRenderingTest(hooks);
 
-  skip('it renders', async function(assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val) { ... });
+  test('it disables clicking if not filled out', async function(assert) {
+    const store = this.owner.lookup('service:store');
+    const model = run(() => store.createRecord('project', {}));
+    this.set('model', model);
+    await render(hbs`{{project-form model=model}}`);
 
-    await render(hbs`{{project-form}}`);
+    assert.equal(this.element.querySelector('[data-test-create-new-project]').disabled, true);
 
-    assert.equal(this.element.textContent.trim(), '');
+    await fillIn('[data-test-new-project-project-name]', 'Mulholland Drive');
+
+    assert.equal(this.element.querySelector('[data-test-create-new-project]').disabled, false);
   });
 });

--- a/tests/integration/components/project-geometries/development-site-test.js
+++ b/tests/integration/components/project-geometries/development-site-test.js
@@ -1,21 +1,62 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, pauseTest, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { run } from '@ember/runloop';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import mapboxGlLoaded from '../../../helpers/mapbox-gl-loaded';
+
+const DUMMY_FEATURE_COLLECTION = {
+  type: 'FeatureCollection',
+  features: [{
+    type: 'Feature',
+    geometry: {
+      type: 'Point',
+      coordinates: [0, 0],
+    },
+  }],
+};
 
 module('Integration | Component | project-geometries/development-site', function(hooks) {
   setupRenderingTest(hooks);
+  setupMirage(hooks);
 
   test('it renders', async function(assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val) { ... });
+    const store = this.owner.lookup('service:store');
+    const model = run(() => store.createRecord('project', {
+      projectName: 'Mulholland Drive',
+    }));
+
+    await model.save();
+
+    this.set('model', model);
 
     await render(hbs`
+      {{!-- EMBER WORMHOLE CONTAINER --}}
+      {{!-- The geometry type component will fill this div with markup once invoked --}}
+      <div id="geometry-type-draw-explainer">
+      </div>
+
+      {{!-- EMBER WORMHOLE CONTAINER --}}
+      <div id="geometry-type-save-box">
+      </div>
+
       {{#mapbox-gl as |map|}} 
-        {{project-geometries/development-site map=map}}
+        <div class="labs-map-loaded"></div>
+        {{project-geometries/development-site
+          mode='lots'
+          map=map
+          model=model}}
       {{/mapbox-gl}}
     `);
 
-    assert.equal(this.element.textContent.trim(), '');
+    await mapboxGlLoaded();
+
+    assert.equal(this.element.querySelector('[data-test-project-geometry-save]').disabled, true);
+
+    await model.set('developmentSite', DUMMY_FEATURE_COLLECTION);
+    await settled();
+
+    assert.equal(this.element.querySelector('[data-test-project-geometry-save]').disabled, false);
   });
 });

--- a/tests/integration/components/project-geometries/development-site-test.js
+++ b/tests/integration/components/project-geometries/development-site-test.js
@@ -21,7 +21,7 @@ module('Integration | Component | project-geometries/development-site', function
   setupRenderingTest(hooks);
   setupMirage(hooks);
 
-  test('it renders', async function(assert) {
+  test('it disables button if there is nothing drawn', async function(assert) {
     const store = this.owner.lookup('service:store');
     const model = run(() => store.createRecord('project', {
       projectName: 'Mulholland Drive',

--- a/tests/integration/components/project-geometries/development-site-test.js
+++ b/tests/integration/components/project-geometries/development-site-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, pauseTest, settled } from '@ember/test-helpers';
+import { render, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { run } from '@ember/runloop';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';

--- a/tests/integration/components/project-geometries/project-area-test.js
+++ b/tests/integration/components/project-geometries/project-area-test.js
@@ -1,21 +1,63 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { run } from '@ember/runloop';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import mapboxGlLoaded from '../../../helpers/mapbox-gl-loaded';
+
+const DUMMY_FEATURE_COLLECTION = {
+  type: 'FeatureCollection',
+  features: [{
+    type: 'Feature',
+    geometry: {
+      type: 'Point',
+      coordinates: [0, 0],
+    },
+  }],
+};
 
 module('Integration | Component | project-geometries/project-area', function(hooks) {
   setupRenderingTest(hooks);
+  setupMirage(hooks);
 
-  test('it renders', async function(assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val) { ... });
+  test('make sure button appears when model is dirty', async function(assert) {
+    const store = this.owner.lookup('service:store');
+    const model = run(() => store.createRecord('project', {
+      projectName: 'Mulholland Drive',
+    }));
+
+    await model.save();
+
+    this.set('model', model);
 
     await render(hbs`
+      {{!-- EMBER WORMHOLE CONTAINER --}}
+      {{!-- The geometry type component will fill this div with markup once invoked --}}
+      <div id="geometry-type-draw-explainer">
+      </div>
+
+      {{!-- EMBER WORMHOLE CONTAINER --}}
+      <div id="geometry-type-save-box">
+      </div>
+
       {{#mapbox-gl as |map|}} 
-        {{project-geometries/project-area map=map}}
+        <div class="labs-map-loaded"></div>
+        {{project-geometries/project-area
+          map=map
+          mode='lots'
+          map=map
+          model=model}}
       {{/mapbox-gl}}
     `);
 
-    assert.equal(this.element.textContent.trim(), '');
+    await mapboxGlLoaded();
+
+    assert.equal(this.element.querySelector('[data-test-project-geometry-save]').disabled, true);
+
+    await model.set('developmentSite', DUMMY_FEATURE_COLLECTION);
+    await settled();
+
+    assert.equal(this.element.querySelector('[data-test-project-geometry-save]').disabled, false);
   });
 });

--- a/tests/unit/utils/wizard-test.js
+++ b/tests/unit/utils/wizard-test.js
@@ -396,7 +396,7 @@ module('Unit | Utility | wizard', function(hooks) {
     assert.equal(step, 'complete');
   });
 
-  test('answers no to all questions but yes to needRezoning, needUnderlyingZoning', function(assert) {
+  test('answers no to all questions but yes to needRezoning, needSpecialDistrict', function(assert) {
     const store = this.owner.lookup('service:store');
     const model = run(() => store.createRecord('area-map', {}));
     let step;
@@ -425,6 +425,50 @@ module('Unit | Utility | wizard', function(hooks) {
       needCommercialOverlay: false,
       needSpecialDistrict: true,
     });
+
+    ({ step } = wizard(projectProcedure, model));
+    assert.equal(step, 'rezoning-special');
+
+    model.set('specialPurposeDistricts', DUMMY_FEATURE_COLLECTION);
+
+    ({ step } = wizard(projectProcedure, model));
+    assert.equal(step, 'complete');
+  });
+
+  test('answers no to all questions but yes to needRezoning, needSpecialDistrict', function(assert) {
+    const store = this.owner.lookup('service:store');
+    const model = run(() => store.createRecord('area-map', {}));
+    let step;
+
+    ({ step } = wizard(projectProcedure, model));
+    assert.equal(step, 'project-creation');
+
+    model.set('projectName', 'Mulholland Drive');
+
+    ({ step } = wizard(projectProcedure, model));
+    assert.equal(step, 'development-site');
+
+    model.set('developmentSite', DUMMY_FEATURE_COLLECTION);
+
+    ({ step } = wizard(projectProcedure, model));
+    assert.equal(step, 'project-area');
+
+    model.set('needProjectArea', false);
+
+    ({ step } = wizard(projectProcedure, model));
+    assert.equal(step, 'rezoning');
+
+    model.setProperties({
+      needRezoning: true,
+      needUnderlyingZoning: false,
+      needCommercialOverlay: true,
+      needSpecialDistrict: true,
+    });
+
+    ({ step } = wizard(projectProcedure, model));
+    assert.equal(step, 'rezoning-commercial');
+
+    model.set('commercialOverlays', DUMMY_FEATURE_COLLECTION);
 
     ({ step } = wizard(projectProcedure, model));
     assert.equal(step, 'rezoning-special');

--- a/tests/unit/utils/wizard-test.js
+++ b/tests/unit/utils/wizard-test.js
@@ -356,4 +356,82 @@ module('Unit | Utility | wizard', function(hooks) {
     ({ step } = wizard(projectProcedure, model));
     assert.equal(step, 'complete');
   });
+
+  test('answers no to all questions but yes to needRezoning, needCommercialOverlay', function(assert) {
+    const store = this.owner.lookup('service:store');
+    const model = run(() => store.createRecord('area-map', {}));
+    let step;
+
+    ({ step } = wizard(projectProcedure, model));
+    assert.equal(step, 'project-creation');
+
+    model.set('projectName', 'Mulholland Drive');
+
+    ({ step } = wizard(projectProcedure, model));
+    assert.equal(step, 'development-site');
+
+    model.set('developmentSite', DUMMY_FEATURE_COLLECTION);
+
+    ({ step } = wizard(projectProcedure, model));
+    assert.equal(step, 'project-area');
+
+    model.set('needProjectArea', false);
+
+    ({ step } = wizard(projectProcedure, model));
+    assert.equal(step, 'rezoning');
+
+    model.setProperties({
+      needRezoning: true,
+      needUnderlyingZoning: false,
+      needCommercialOverlay: true,
+      needSpecialDistrict: false,
+    });
+
+    ({ step } = wizard(projectProcedure, model));
+    assert.equal(step, 'rezoning-commercial');
+
+    model.set('commercialOverlays', DUMMY_FEATURE_COLLECTION);
+
+    ({ step } = wizard(projectProcedure, model));
+    assert.equal(step, 'complete');
+  });
+
+  test('answers no to all questions but yes to needRezoning, needUnderlyingZoning', function(assert) {
+    const store = this.owner.lookup('service:store');
+    const model = run(() => store.createRecord('area-map', {}));
+    let step;
+
+    ({ step } = wizard(projectProcedure, model));
+    assert.equal(step, 'project-creation');
+
+    model.set('projectName', 'Mulholland Drive');
+
+    ({ step } = wizard(projectProcedure, model));
+    assert.equal(step, 'development-site');
+
+    model.set('developmentSite', DUMMY_FEATURE_COLLECTION);
+
+    ({ step } = wizard(projectProcedure, model));
+    assert.equal(step, 'project-area');
+
+    model.set('needProjectArea', false);
+
+    ({ step } = wizard(projectProcedure, model));
+    assert.equal(step, 'rezoning');
+
+    model.setProperties({
+      needRezoning: true,
+      needUnderlyingZoning: false,
+      needCommercialOverlay: false,
+      needSpecialDistrict: true,
+    });
+
+    ({ step } = wizard(projectProcedure, model));
+    assert.equal(step, 'rezoning-special');
+
+    model.set('specialPurposeDistricts', DUMMY_FEATURE_COLLECTION);
+
+    ({ step } = wizard(projectProcedure, model));
+    assert.equal(step, 'complete');
+  });
 });

--- a/tests/unit/utils/wizard-test.js
+++ b/tests/unit/utils/wizard-test.js
@@ -27,7 +27,7 @@ module('Unit | Utility | wizard', function(hooks) {
   // Replace this with your real tests.
   test('answers yes to all questions', function(assert) {
     const store = this.owner.lookup('service:store');
-    const model = run(() => store.createRecord('area-map', {}));
+    const model = run(() => store.createRecord('project', {}));
     let step;
 
     ({ step } = wizard(projectProcedure, model));


### PR DESCRIPTION
This PR creates additional tests for disabling buttons when model is not dirty. Adds a simple undo button for running 'rollbackAttributes' on the model.