### PR TITLE
Fix Feature Delete Regression

### DIFF
--- a/app/components/project-geometries/modes/draw.js
+++ b/app/components/project-geometries/modes/draw.js
@@ -30,15 +30,10 @@ export default class DrawComponent extends Component {
 
     mapInstance.addControl(draw, 'top-left');
 
-    // set up initial drawing mode
-    draw.changeMode('draw_polygon');
-
     // if geometry exists for this mode, add it to the drawing canvas
     if (!isEmpty(geometricProperty)) {
       draw.add(geometricProperty);
     }
-
-    draw.changeMode('simple_select');
 
     const drawStateCallback = () => {
       if (!this.get('isDestroyed')) {
@@ -111,7 +106,14 @@ export default class DrawComponent extends Component {
 
   @action
   handleTrashButtonClick() {
-    draw.trash();
+    const selectedFeature = draw.getSelectedIds();
+    const selectedVertices = draw.getSelectedPoints();
+
+    if (selectedVertices.features[0]) {
+      draw.trash();
+    } else {
+      draw.delete(selectedFeature);
+    }
   }
 
   @action

--- a/app/templates/components/project-geometries/commercial-overlays.hbs
+++ b/app/templates/components/project-geometries/commercial-overlays.hbs
@@ -33,7 +33,7 @@
           {{fa-icon 'square' transform='grow-8' class='white'}}
           {{fa-icon 'trash-alt' prefix='far' transform='shrink-2'}}
         </span>
-        trash button (or delete key) to delete a selected shape or vertex
+        trash button to delete a selected shape or vertex
       </p></li>
       <li><p class="small-margin-bottom">
         When a shape is complete/selected, you can edit its

--- a/app/templates/components/project-geometries/development-site.hbs
+++ b/app/templates/components/project-geometries/development-site.hbs
@@ -30,7 +30,7 @@
               {{fa-icon 'square' transform='grow-8' class='white'}}
               {{fa-icon 'trash-alt' prefix='far' transform='shrink-2'}}
             </span>
-            trash button (or delete key) to delete a selected shape or vertex
+            trash button to delete a selected shape or vertex
           </p></li>
           <li><p class="small-margin-bottom">Make sure all shapes are complete before saving</p></li>
         </ul>

--- a/app/templates/components/project-geometries/project-area.hbs
+++ b/app/templates/components/project-geometries/project-area.hbs
@@ -30,7 +30,7 @@
             {{fa-icon 'square' transform='grow-8' class='white'}}
             {{fa-icon 'trash-alt' prefix='far' transform='shrink-2'}}
           </span>
-          trash button (or delete key) to delete a selected shape or vertex
+          trash button to delete a selected shape or vertex
         </p></li>
         <li><p class="small-margin-bottom">Make sure all shapes are complete before saving</p></li>
       </ul>

--- a/app/templates/components/project-geometries/rezoning-area.hbs
+++ b/app/templates/components/project-geometries/rezoning-area.hbs
@@ -29,7 +29,7 @@
           {{fa-icon 'square' transform='grow-8' class='white'}}
           {{fa-icon 'trash-alt' prefix='far' transform='shrink-2'}}
         </span>
-        trash button (or delete key) to delete a selected shape or vertex
+        trash button to delete a selected shape or vertex
       </p></li>
       <li><p class="small-margin-bottom">Make sure all shapes are complete before saving</p></li>
     </ul>

--- a/app/templates/components/project-geometries/special-purpose-districts.hbs
+++ b/app/templates/components/project-geometries/special-purpose-districts.hbs
@@ -31,7 +31,7 @@
           {{fa-icon 'square' transform='grow-8' class='white'}}
           {{fa-icon 'trash-alt' prefix='far' transform='shrink-2'}}
         </span>
-        trash button (or delete key) to delete a selected shape or vertex
+        trash button to delete a selected shape or vertex
       </p></li>
       <li><p class="small-margin-bottom">
         When a shape is complete/selected, you can edit its

--- a/app/templates/components/project-geometries/underlying-zoning.hbs
+++ b/app/templates/components/project-geometries/underlying-zoning.hbs
@@ -31,7 +31,7 @@
           {{fa-icon 'square' transform='grow-8' class='white'}}
           {{fa-icon 'trash-alt' prefix='far' transform='shrink-2'}}
         </span>
-        trash button (or delete key) to delete a selected shape or vertex
+        trash button to delete a selected shape or vertex
       </p></li>
       <li><p class="small-margin-bottom">
         When a shape is complete/selected, you can edit its


### PR DESCRIPTION
#254 introduced a bug where you could not delete features (`direct_select` mode can only delete vertices). This PR remedies that by adding logic to the custom trash button which fires `delete(ids)` instead of `trash()` if no vertices are selected. 

The caveat is that you can't use `Delete`/`Backspace` keys to delete features (tho keys do delete vertices). You must use the custom trash button to delete features. The instructions have been updated accordingly. 

This caveat is a trade-off for skipping `simple_select` mode. The mode is bypassed to improve UX, so that you can drag vertices as soon as a feature is selected, without requiring additional clicks. @trbmcginnis and I decided that it's worth losing the keys for deleting features in order to have a more intuitive vertex editing UX. 

@allthesignals @chriswhong If y'all can think of any way to get around this trade-off, please let us know. 