### PR TITLE
Geom Edit Buttons

### DIFF
--- a/app/templates/components/project-geometries.hbs
+++ b/app/templates/components/project-geometries.hbs
@@ -46,15 +46,16 @@
               class='button gray expanded'
               disabled=(not model.hasDirtyAttributes)
             }}
-              Manual Edit
+              Switch to Manual Drawing
+              <small style="display:block;line-height:1.75;">(edit the shape with draw tools)</small>
             {{/link-to}}
           {{/if}}
-          <button class="button smal gray expanded" 
+          {{!-- <button class="button smal gray expanded"
             disabled={{not model.hasDirtyAttributes}}
             onclick={{action 'rollbackChanges'}}
           >
             Undo
-          </button>
+          </button> --}}
         </div>
       {{/ember-wormhole}}
     {{/labs-map}}


### PR DESCRIPTION
This simple PR… 
- Edits the label of the button that switches to draw mode 
- Comments out the "Undo" button (since it's confusing as-is, let's clarify the need for resetting/undo/redo in user testing)

![image](https://user-images.githubusercontent.com/409279/49246200-4aecee00-f3e2-11e8-95b0-900be2e3582c.png)
