### PR TITLE
292 steps to complete

### DIFF
--- a/app/controllers/projects/edit/steps.js
+++ b/app/controllers/projects/edit/steps.js
@@ -1,0 +1,17 @@
+import Controller from '@ember/controller';
+import { service } from '@ember-decorators/service';
+import { computed } from '@ember-decorators/object';
+
+export default class StepsController extends Controller {
+  @service
+  router;
+
+  @computed('router.currentRouteName')
+  get currentStepNumber() {
+    const currentRouteName = this.get('router.currentRouteName');
+
+    if (currentRouteName === 'projects.edit.steps.rezoning') { return 3; }
+    if (currentRouteName === 'projects.edit.steps.project-area') { return 2; }
+    return 1;
+  }
+}

--- a/app/models/project.js
+++ b/app/models/project.js
@@ -298,15 +298,6 @@ export default class extends Model {
     return wizard(projectProcedure, this);
   }
 
-  @computed('currentStep')
-  get currentStepNumber() {
-    const currentStep = this.get('currentStep');
-    if (currentStep.step === 'rezoning') { return 3; }
-    if (currentStep.step === 'complete') { return 3; }
-    if (currentStep.step === 'project-area') { return 2; }
-    return 1;
-  }
-
   // ******** CHECKS AND METHODS FOR REZONING QUESTIONS ********
   setRezoningFalse() {
     this.set('needRezoning', false);

--- a/app/templates/projects/edit/steps.hbs
+++ b/app/templates/projects/edit/steps.hbs
@@ -5,34 +5,34 @@
   <h6>Steps to be completed:</h6>
   <ul class="no-bullet light-gray">
     <li class="
-      {{if (gte model.currentStepNumber 1) 'black'}}
-      {{if (eq model.currentStepNumber 1) 'text-weight-bold'}}
+      {{if (gte currentStepNumber 1) 'black'}}
+      {{if (eq currentStepNumber 1) 'text-weight-bold'}}
     ">
-      {{fa-icon (if (eq model.currentStepNumber 1) 'arrow-alt-circle-right' 'check')
+      {{fa-icon (if (eq currentStepNumber 1) 'arrow-alt-circle-right' 'check')
         fixedWidth=true
-        class=(if (gt model.currentStepNumber 1) 'green-muted' '')
+        class=(if (gt currentStepNumber 1) 'green-muted' '')
       }}
       Development Site
     </li>
     <li class="
-      {{if (gte model.currentStepNumber 2) 'black'}}
-      {{if (eq model.currentStepNumber 2) 'text-weight-bold'}}
+      {{if (gte currentStepNumber 2) 'black'}}
+      {{if (eq currentStepNumber 2) 'text-weight-bold'}}
     ">
-      {{fa-icon (if (eq model.currentStepNumber 2) 'arrow-alt-circle-right' (if (gt model.currentStepNumber 2) 'check' 'circle'))
+      {{fa-icon (if (eq currentStepNumber 2) 'arrow-alt-circle-right' (if (gt currentStepNumber 2) 'check' 'circle'))
         fixedWidth=true
-        class=(if (gt model.currentStepNumber 2) 'green-muted' '')
-        prefix=(unless (gte model.currentStepNumber 2) 'far' 'fas')
+        class=(if (gt currentStepNumber 2) 'green-muted' '')
+        prefix=(unless (gte currentStepNumber 2) 'far' 'fas')
       }}
       Project Area
     </li>
     <li class="
-      {{if (gte model.currentStepNumber 3) 'black'}}
-      {{if (eq model.currentStepNumber 3) 'text-weight-bold'}}
+      {{if (gte currentStepNumber 3) 'black'}}
+      {{if (eq currentStepNumber 3) 'text-weight-bold'}}
     ">
-      {{fa-icon (if (eq model.currentStepNumber 3) 'arrow-alt-circle-right' (if (gt model.currentStepNumber 3) 'check' 'circle'))
+      {{fa-icon (if (eq currentStepNumber 3) 'arrow-alt-circle-right' (if (gt currentStepNumber 3) 'check' 'circle'))
         fixedWidth=true
-        class=(if (gt model.currentStepNumber 3) 'green-muted' '')
-        prefix=(unless (gte model.currentStepNumber 3) 'far' 'fas')
+        class=(if (gt currentStepNumber 3) 'green-muted' '')
+        prefix=(unless (gte currentStepNumber 3) 'far' 'fas')
       }}
       Rezoning
     </li>

--- a/tests/unit/controllers/projects/edit/steps-test.js
+++ b/tests/unit/controllers/projects/edit/steps-test.js
@@ -1,12 +1,25 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import Service from '@ember/service';
 
 module('Unit | Controller | projects/edit/steps', function(hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
-  test('it exists', function(assert) {
+  test('currentStepNumber is defined by the nested route', function(assert) {
+    this.owner.register('service:router', Service.extend({
+      currentRouteName: 'index',
+    }));
+
+    const routerServiceStub = this.owner.lookup('service:router');
     const controller = this.owner.lookup('controller:projects/edit/steps');
-    assert.ok(controller);
+
+    routerServiceStub.set('currentRouteName', 'projects.edit.steps.development-site');
+    assert.equal(controller.get('currentStepNumber'), 1);
+
+    routerServiceStub.set('currentRouteName', 'projects.edit.steps.project-area');
+    assert.equal(controller.get('currentStepNumber'), 2);
+
+    routerServiceStub.set('currentRouteName', 'projects.edit.steps.rezoning');
+    assert.equal(controller.get('currentStepNumber'), 3);
   });
 });

--- a/tests/unit/controllers/projects/edit/steps-test.js
+++ b/tests/unit/controllers/projects/edit/steps-test.js
@@ -6,7 +6,7 @@ module('Unit | Controller | projects/edit/steps', function(hooks) {
 
   // Replace this with your real tests.
   test('it exists', function(assert) {
-    let controller = this.owner.lookup('controller:projects/edit/steps');
+    const controller = this.owner.lookup('controller:projects/edit/steps');
     assert.ok(controller);
   });
 });

--- a/tests/unit/controllers/projects/edit/steps-test.js
+++ b/tests/unit/controllers/projects/edit/steps-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | projects/edit/steps', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let controller = this.owner.lookup('controller:projects/edit/steps');
+    assert.ok(controller);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3237,7 +3237,6 @@ cartobox-promises-utility@nycplanning/cartobox-promises-utility#v1.0.2:
   resolved "https://codeload.github.com/nycplanning/cartobox-promises-utility/tar.gz/57f1c96a0bf03c47e048c30d202643cc49db3c69"
   dependencies:
     ember-cli-babel "^6.6.0"
-    ember-fetch "4.0.1"
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
This PR closes #292 by refactoring the way `currentStepNumber` is computed. 

Previously, `currentStep` on the project was used to compute the step as a number, which is used by "greater than" and "equal to" conditions in the `steps` template. However, all we really need to know is which nested route we're on. 

Now, `currentStepNumber` is computed by the `steps` controller which simply looks up `currentRouteName`. 

@allthesignals I'd like to write a test for this. But I'm not certain what the best type of test would be. Would I need to write an acceptance test (similar to `user-can-create-project-with-map`) that goes through the whole wizard, checking that this works at each step?  