### PR TITLE
330 get selected ids error

### DIFF
--- a/app/components/project-geometries/modes/draw.js
+++ b/app/components/project-geometries/modes/draw.js
@@ -20,6 +20,18 @@ MapboxDraw.modes.direct_select.onFeature = function() {
   this.map.dragPan.enable();
 };
 
+// setup events to update draw state
+// bind events to the state callback
+const callBackStateEvents = [
+  'create',
+  'combine',
+  'uncombine',
+  'update',
+  'selectionchange',
+  'modechange',
+  'delete',
+];
+
 export default class DrawComponent extends Component {
   constructor(...args) {
     super(...args);
@@ -68,15 +80,7 @@ export default class DrawComponent extends Component {
 
     // setup events to update draw state
     // bind events to the state callback
-    [
-      'create',
-      'combine',
-      'uncombine',
-      'update',
-      'selectionchange',
-      'modechange',
-      'delete',
-    ]
+    callBackStateEvents
       .forEach((event) => {
         mapInstance.on(`draw.${event}`, drawStateCallback);
       });
@@ -148,7 +152,11 @@ export default class DrawComponent extends Component {
     const { draw } = this.get('map');
     const { mapInstance } = this.get('map');
 
-    mapInstance.off('draw.selectionchange');
+    // turn off all events for teardown
+    callBackStateEvents.forEach((event) => {
+      mapInstance.off(`draw.${event}`);
+    });
+
     mapInstance.removeControl(draw);
   }
 }

--- a/app/components/project-geometries/modes/draw.js
+++ b/app/components/project-geometries/modes/draw.js
@@ -6,7 +6,7 @@ import { type } from '@ember-decorators/argument/type';
 import { FeatureCollection, EmptyFeatureCollection } from '../../../models/project';
 import isEmpty from '../../../utils/is-empty';
 
-export const DefaultDraw = MapboxDraw.bind(null, {
+export const DefaultDraw = new MapboxDraw({
   displayControlsDefault: false,
   controls: {
     polygon: true,
@@ -38,7 +38,7 @@ export default class DrawComponent extends Component {
 
     const {
       mapInstance,
-      draw = new DefaultDraw(),
+      draw = DefaultDraw,
     } = this.get('map');
 
     // set draw instance so it's available to the class
@@ -53,22 +53,6 @@ export default class DrawComponent extends Component {
       draw.add(geometricProperty);
     }
 
-    const drawStateCallback = () => {
-      if (!this.get('isDestroyed')) {
-        this.setProperties({
-          geometricProperty: draw.getAll(),
-          drawMode: draw.getMode(),
-        });
-
-        const { features: [firstSelectedFeature] } = draw.getSelected();
-        if (firstSelectedFeature) {
-          this.set('selectedFeature', { type: 'FeatureCollection', features: [firstSelectedFeature] });
-        } else {
-          this.set('selectedFeature', EmptyFeatureCollection);
-        }
-      }
-    };
-
     this.addObserver('geometricProperty', () => {
       const latestProperty = this.get('geometricProperty');
       if (!isEmpty(latestProperty)) {
@@ -82,7 +66,8 @@ export default class DrawComponent extends Component {
     // bind events to the state callback
     callBackStateEvents
       .forEach((event) => {
-        mapInstance.on(`draw.${event}`, drawStateCallback);
+        mapInstance.off(`draw.${event}`, this.drawStateCallback.bind(this));
+        mapInstance.on(`draw.${event}`, this.drawStateCallback.bind(this));
       });
 
     // skip simple_select mode, jump straight to direct_select mode so users can immediately select vertices
@@ -94,6 +79,24 @@ export default class DrawComponent extends Component {
         draw.changeMode('direct_select', { featureId: selected });
       }
     });
+  }
+
+  drawStateCallback() {
+    const { draw } = this.get('map');
+    console.log(this.get('elementId'));
+    if (!this.get('isDestroyed') && !this.get('isDestroying')) {
+      this.setProperties({
+        geometricProperty: draw.getAll(),
+        drawMode: draw.getMode(),
+      });
+
+      const { features: [firstSelectedFeature] } = draw.getSelected();
+      if (firstSelectedFeature) {
+        this.set('selectedFeature', { type: 'FeatureCollection', features: [firstSelectedFeature] });
+      } else {
+        this.set('selectedFeature', EmptyFeatureCollection);
+      }
+    }
   }
 
   @argument
@@ -147,16 +150,17 @@ export default class DrawComponent extends Component {
   }
 
   willDestroyElement(...args) {
-    super.willDestroyElement(...args);
-
     const { draw } = this.get('map');
     const { mapInstance } = this.get('map');
 
-    // turn off all events for teardown
-    callBackStateEvents.forEach((event) => {
-      mapInstance.off(`draw.${event}`);
-    });
+    callBackStateEvents
+      .forEach((event) => {
+        mapInstance.off(`draw.${event}`, this.drawStateCallback.bind(this));
+      });
 
+    draw.deleteAll();
     mapInstance.removeControl(draw);
+
+    super.willDestroyElement(...args);
   }
 }

--- a/mirage/fixtures/projects.js
+++ b/mirage/fixtures/projects.js
@@ -1,0 +1,93 @@
+export default [
+  {
+    id: 10,
+    projectName: 'test',
+    developmentSite: {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          properties: {},
+          geometry: {
+            type: 'Polygon',
+            coordinates: [
+              [
+                [
+                  -73.91304371809123,
+                  40.75800497849508,
+                ],
+                [
+                  -73.91272236764055,
+                  40.75785653226183,
+                ],
+                [
+                  -73.91253338845002,
+                  40.75808671409273,
+                ],
+                [
+                  -73.91285462634531,
+                  40.75823546499302,
+                ],
+                [
+                  -73.91295060921382,
+                  40.758120288754554,
+                ],
+                [
+                  -73.91304371809123,
+                  40.75800497849508,
+                ],
+              ],
+            ],
+          },
+        },
+      ],
+    },
+    projectArea: {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          properties: {},
+          geometry: {
+            type: 'Polygon',
+            coordinates: [
+              [
+                [
+                  -73.91304371809123,
+                  40.75800497849508,
+                ],
+                [
+                  -73.91272236764055,
+                  40.75785653226183,
+                ],
+                [
+                  -73.91253338845002,
+                  40.75808671409273,
+                ],
+                [
+                  -73.91285462634531,
+                  40.75823546499302,
+                ],
+                [
+                  -73.91295060921382,
+                  40.758120288754554,
+                ],
+                [
+                  -73.91304371809123,
+                  40.75800497849508,
+                ],
+              ],
+            ],
+          },
+        },
+      ],
+    },
+    applicantName: 'test',
+    zapProjectId: 'test',
+    needProjectArea: true,
+    needRezoning: true,
+    needUnderlyingZoning: true,
+    needCommercialOverlay: true,
+    needSpecialDistrict: true,
+  },
+];

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -4,6 +4,6 @@ export default function(server) {
     This data will not be loaded in your tests.
   */
 
-  server.createList('project', 10);
+  server.loadFixtures('projects');
   server.createList('layer-group', 3);
 }

--- a/tests/integration/components/project-geometries/modes/draw-test.js
+++ b/tests/integration/components/project-geometries/modes/draw-test.js
@@ -5,7 +5,6 @@ import {
   click,
   waitUntil,
   typeIn,
-  // pauseTest,
 } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -18,7 +17,7 @@ module('Integration | Component | project-geometries/modes/draw', function(hooks
 
   hooks.before(async function() {
     this.map = await createMap();
-    this.draw = new DefaultDraw();
+    this.draw = DefaultDraw;
   });
 
   hooks.after(function() {


### PR DESCRIPTION
Closes #330 

This PR fixes a major issue that appeared with creating new polygons. 

It was at some point no longer possible to add polygons twice in a row. There was some evidence of a memory leak - across draw component invocations, callback events were still stuck to previous instances of the component.

Additionally, something seemed to be happening with the instantiation of MapboxGL Draw. Originally, we export a pre-configured mapbox-gl-draw object so it's available as a test. This way it isn't globally instantiated. Now it is globally instantiated singleton, it's added and removed to the map as-needed. Unsure if this will cause problems later, but it solves this immediate issue.

NOTE: I've added a fixture file for projects. This allows us to statically set up some test projects. See `mirage/fixtures/projects.js`. If you would like to add more fixture, just add it as an object to the array in that file. You can use any id you'd like, I'd start from 1-9. 