### PR TITLE
make pitchWithRotate false on all maps

### DIFF
--- a/app/templates/components/map-form.hbs
+++ b/app/templates/components/map-form.hbs
@@ -34,17 +34,17 @@
         onclick={{action 'reorientPaper' 'portrait'}}
         data-test-paper-orientation-portrait
       />
-        
+
       <label for="paper-orientation--portrait">
         Portrait
       </label>
-      <input 
-        type="radio" 
-        name="paper-orientation" 
-        class="landscape-radio-button" 
-        value="landscape" 
-        id="paper-orientation--landscape" 
-        checked={{eq model.paperOrientation "landscape"}}  
+      <input
+        type="radio"
+        name="paper-orientation"
+        class="landscape-radio-button"
+        value="landscape"
+        id="paper-orientation--landscape"
+        checked={{eq model.paperOrientation "landscape"}}
         onclick={{action 'reorientPaper' 'landscape'}}
         data-test-paper-orientation-landscape
       />
@@ -54,21 +54,21 @@
     </p>
     <p>
       <input
-        type="radio" 
-        name="paper-size" 
-        class="tabloid-radio-button" 
-        value="tabloid" 
-        id="paper-size--tabloid" 
-        checked={{eq model.paperSize "tabloid"}} 
+        type="radio"
+        name="paper-size"
+        class="tabloid-radio-button"
+        value="tabloid"
+        id="paper-size--tabloid"
+        checked={{eq model.paperSize "tabloid"}}
         onclick={{action 'scalePaper' 'tabloid'}}
         data-test-paper-paper-size-tabloid
       />
       <label for="paper-size--tabloid">Tabloid</label>
-      <input 
-        type="radio" 
-        name="paper-size" 
-        class="letter-radio-button" value="letter" id="paper-size--letter" 
-        checked={{eq model.paperSize "letter"}} 
+      <input
+        type="radio"
+        name="paper-size"
+        class="letter-radio-button" value="letter" id="paper-size--letter"
+        checked={{eq model.paperSize "letter"}}
         onclick={{action  'scalePaper' 'letter'}}
         data-test-paper-paper-size-letter
       />
@@ -76,20 +76,20 @@
     </p>
 
     <h5>Project Area Buffer</h5>
-    <input 
-      type="radio" 
-      name="buffer-size" 
-      checked={{eq model.bufferSize "600"}} 
-      id="buffer-size--600" 
+    <input
+      type="radio"
+      name="buffer-size"
+      checked={{eq model.bufferSize "600"}}
+      id="buffer-size--600"
       onclick={{action 'setBufferSize' '600'}}
       data-test-project-area-buffer
     />
     <label for="buffer-size--600">600ft</label>
-    <input 
-      type="radio" 
-      name="buffer-size" 
-      checked={{eq model.bufferSize "400"}} 
-      id="buffer-size--400" 
+    <input
+      type="radio"
+      name="buffer-size"
+      checked={{eq model.bufferSize "400"}}
+      id="buffer-size--400"
       onclick={{action 'setBufferSize' '400'}}
       data-test-project-area-buffer-400
     />
@@ -107,10 +107,10 @@
         {{fa-icon 'arrow-left'}}
         Go Back to Project
       {{/link-to}}
-      <button 
-        class="cell auto button project-save-button" 
-        type="button" 
-        onclick={{action 'saveProject'}} 
+      <button
+        class="cell auto button project-save-button"
+        type="button"
+        onclick={{action 'saveProject'}}
         disabled={{not model.hasDirtyAttributes}}
         data-test-save-map
       >Save Map</button>
@@ -175,7 +175,7 @@
             id='main-map'
             initOptions=(hash
               style=mapConfiguration.meta.mapboxStyle
-
+              pitchWithRotate=false
             )
             mapLoaded=(action 'handleMapLoaded') as |map|
           }}

--- a/app/templates/components/map-form/inset-map.hbs
+++ b/app/templates/components/map-form/inset-map.hbs
@@ -4,6 +4,7 @@
       zoom=8
       center=(array -73.96532400540775 40.709710016659386)
       interactive=false
+      pitchWithRotate=false
     )
     mapLoaded=(action 'handleMapLoad') as | map |
 }}

--- a/app/templates/components/project-geometries.hbs
+++ b/app/templates/components/project-geometries.hbs
@@ -17,6 +17,7 @@
         style=projectMapForm.model.meta.mapboxStyle
         zoom=12
         center=(array -73.983307 40.704977)
+        pitchWithRotate=false
       )
       mapLoaded=(action 'handleMapLoad') as |map|}}
 

--- a/app/templates/projects/show.hbs
+++ b/app/templates/projects/show.hbs
@@ -21,6 +21,7 @@
             zoom=15.479951257235973
             center=(array -73.96532400540775 40.709710016659386)
             bearing=20.97777777785973
+            pitchWithRotate=false
           )
           as | map |
         }}


### PR DESCRIPTION
Adds `pitchWithRotate: false` to the `initOptions` of all four map implementations, disabling user-controlled pitch.  Closes #188