### PR TITLE
Area map download

### DIFF
--- a/app/components/map-form.js
+++ b/app/components/map-form.js
@@ -9,6 +9,9 @@ import { sanitizeStyle } from 'labs-applicant-maps/helpers/sanitize-style';
 // TODO import geom layers from the various modes that export them,
 // this util should be deprecated
 import projectGeomLayers from '../utils/project-geom-layers';
+import config from '../config/environment';
+
+const { host } = config;
 
 const defaultLayerGroups = {
   'layer-groups': [
@@ -240,7 +243,7 @@ export default class MapFormComponent extends Component {
   @computed
   get downloadURL() {
     const id = this.get('model.project.id');
-    return `http://localhost:3000/export-pdf/${id}`;
+    return `${host}/export-pdf/${encodeURIComponent(id)}`;
   }
 
   @action

--- a/app/components/map-form.js
+++ b/app/components/map-form.js
@@ -237,6 +237,12 @@ export default class MapFormComponent extends Component {
     }]);
   }
 
+  @computed
+  get downloadURL() {
+    const id = this.get('model.project.id');
+    return `http://localhost:3000/export-pdf/${id}`;
+  }
+
   @action
   handleMapLoaded(map) {
     this.set('mapInstance', map);

--- a/app/styles/_foundation-print.scss
+++ b/app/styles/_foundation-print.scss
@@ -6,7 +6,7 @@
 /// @type Boolean
 /// @group global
 $print-transparent-backgrounds: true !default;
-$print-hrefs: true !default;
+$print-hrefs: false;
 
 // sass-lint:disable-all
 

--- a/app/templates/components/map-form.hbs
+++ b/app/templates/components/map-form.hbs
@@ -120,9 +120,21 @@
     <hr/>
 
     <div class="grid-x grid-margin-x">
-      <p class="cell shrink medium-5">
+      <p class="cell shrink medium-6">
         <button class="button gray expanded" type="button" onClick=print()>{{fa-icon 'print'}} Print</button></p>
       <p class="cell auto text-tiny dark-gray">Make sure your system's print settings enable printing background graphics and that the paper size and orientation match your map.</p>
+    </div>
+
+    <div class="grid-x grid-margin-x">
+      <p class="cell shrink medium-6">
+        <form action="{{downloadURL}}" target="_blank">
+          <input type=hidden name=orientation value={{model.paperOrientation}}>
+          <input type=hidden name=size value={{model.paperSize}}>
+          <button class="button gray expanded" type="submit">{{fa-icon 'file-pdf'}} Download</button>
+        </form>
+      </p>
+
+      <p class="cell auto text-tiny dark-gray">The PDF may take several seconds to generate.</p>
     </div>
 
   </div>


### PR DESCRIPTION
Adds a button to generate a PDF of the area map, consuming the new `export-pdf` endpoint on the applicantmaps API.  (https://github.com/NYCPlanning/labs-applicantmaps-api/pull/6)