### PR TITLE
Interactive Tax Lots

### DIFF
--- a/app/components/project-geometries.js
+++ b/app/components/project-geometries.js
@@ -194,14 +194,6 @@ export default class ProjectGeometryEditComponent extends Component {
     const store = this.get('store');
     store.query('layer-group', mapEditingLayerGroups).then((allLayerGroups) => {
       const { meta } = allLayerGroups;
-
-      // let layerGroups = allLayerGroups;
-      //
-      // // If we're selecting lots, disable the default tax lots layer group
-      // // The selectable tax lots layer is added in lots.hbs
-      // if (this.get('mode') === 'lots') {
-      //   layerGroups = allLayerGroups.filter(layerGroup => layerGroup.get('id') !== 'tax-lots');
-      // }
       const layerGroups = allLayerGroups;
 
       this.set('layerGroups', {

--- a/app/components/project-geometries.js
+++ b/app/components/project-geometries.js
@@ -195,11 +195,11 @@ export default class ProjectGeometryEditComponent extends Component {
     basemapLayersToHide.forEach(layer => map.removeLayer(layer));
   }
 
+  // TODO: This function seems awkward. layerGroups.layerGroups?
   loadLayerGroups() {
     const store = this.get('store');
-    store.query('layer-group', mapEditingLayerGroups).then((allLayerGroups) => {
-      const { meta } = allLayerGroups;
-      const layerGroups = allLayerGroups;
+    store.query('layer-group', mapEditingLayerGroups).then((layerGroups) => {
+      const { meta } = layerGroups;
 
       this.set('layerGroups', {
         layerGroups,

--- a/app/components/project-geometries.js
+++ b/app/components/project-geometries.js
@@ -14,7 +14,7 @@ const mapEditingLayerGroups = {
       id: 'tax-lots',
       visible: true,
       layers: [
-        { tooltipable: false, highlightable: true, tooltipTemplate: '{{address}} (BBL: {{bbl}})' },
+        { tooltipable: true, highlightable: true, tooltipTemplate: '{{address}} (BBL: {{bbl}})' },
         {},
         { style: { layout: { 'text-field': '{lot}' } } },
         {
@@ -194,7 +194,15 @@ export default class ProjectGeometryEditComponent extends Component {
     const store = this.get('store');
     store.query('layer-group', mapEditingLayerGroups).then((allLayerGroups) => {
       const { meta } = allLayerGroups;
-      const layerGroups = allLayerGroups.filter(layerGroup => layerGroup.get('id') !== 'tax-lots');
+
+      // let layerGroups = allLayerGroups;
+      //
+      // // If we're selecting lots, disable the default tax lots layer group
+      // // The selectable tax lots layer is added in lots.hbs
+      // if (this.get('mode') === 'lots') {
+      //   layerGroups = allLayerGroups.filter(layerGroup => layerGroup.get('id') !== 'tax-lots');
+      // }
+      const layerGroups = allLayerGroups;
 
       this.set('layerGroups', {
         layerGroups,

--- a/app/components/project-geometries.js
+++ b/app/components/project-geometries.js
@@ -14,7 +14,12 @@ const mapEditingLayerGroups = {
       id: 'tax-lots',
       visible: true,
       layers: [
-        { tooltipable: true, highlightable: true, tooltipTemplate: '{{address}} (BBL: {{bbl}})' },
+        {
+          highlightable: true,
+          clickable: false,
+          tooltipable: true,
+          tooltipTemplate: '{{address}} (BBL: {{bbl}})',
+        },
         {},
         { style: { layout: { 'text-field': '{lot}' } } },
         {

--- a/app/components/project-geometries/modes/draw.js
+++ b/app/components/project-geometries/modes/draw.js
@@ -75,12 +75,6 @@ export default class DrawComponent extends Component {
     }
   }
 
-  @computed()
-  get taxLots() {
-    const taxLotsLayerGroup = this.get('store').peekRecord('layer-group', 'tax-lots');
-    return taxLotsLayerGroup;
-  }
-
   // Get drawn features, if they're valid
   // We need to remove weird null coordinates.
   // This makes the component expect a certain type of FC

--- a/app/components/project-geometries/modes/draw.js
+++ b/app/components/project-geometries/modes/draw.js
@@ -75,6 +75,12 @@ export default class DrawComponent extends Component {
     }
   }
 
+  @computed()
+  get taxLots() {
+    const taxLotsLayerGroup = this.get('store').peekRecord('layer-group', 'tax-lots');
+    return taxLotsLayerGroup;
+  }
+
   // Get drawn features, if they're valid
   // We need to remove weird null coordinates.
   // This makes the component expect a certain type of FC

--- a/app/components/project-geometries/modes/lots.js
+++ b/app/components/project-geometries/modes/lots.js
@@ -32,12 +32,28 @@ export default class LotsComponent extends Component {
       features: [],
     });
 
-    const plutoFillLayer = this.get('store').peekRecord('layer', 'pluto-fill');
+    // Add the interactive tax lots layer group to the store
+    const interactiveTaxLotsLayerGroup = this.store.createRecord('layer-group', {
+      id: 'tax-lots-interactive',
+      visible: true,
+    });
 
-    if (plutoFillLayer && !this.get('isDestroyed')) {
-      plutoFillLayer.set('highlightable', true);
-      plutoFillLayer.set('tooltipable', true);
-    }
+    // Add the interactive tax lots layer to the store
+    this.store.createRecord('layer', {
+      id: 'pluto-fill-interactive',
+      style: {
+        id: 'pluto-fill-interactive',
+        type: 'fill',
+        source: 'pluto',
+        minzoom: 15,
+        'source-layer': 'pluto',
+        paint: {
+          'fill-opacity': 0,
+        },
+      },
+      clickable: true,
+      layerGroup: interactiveTaxLotsLayerGroup,
+    });
   }
 
   @argument
@@ -52,9 +68,8 @@ export default class LotsComponent extends Component {
   selectedLotsLayer = selectedLotsLayer;
 
   @computed()
-  get taxLots() {
-    const taxLotsLayerGroup = this.get('store').peekRecord('layer-group', 'tax-lots');
-    return taxLotsLayerGroup;
+  get interactiveTaxLots() {
+    return this.get('store').peekRecord('layer-group', 'tax-lots-interactive');
   }
 
   @computed('geometricProperty.features.@each.geometry')
@@ -136,11 +151,12 @@ export default class LotsComponent extends Component {
   }
 
   willDestroyElement() {
-    const plutoFillLayer = this.get('store').peekRecord('layer', 'pluto-fill');
+    // Remove the interactive tax lots layer from the store
+    const destroyableTaxLotsLayer = this.get('store').peekRecord('layer', 'pluto-fill-interactive');
+    destroyableTaxLotsLayer.unloadRecord();
 
-    if (plutoFillLayer && !this.get('isDestroyed')) {
-      plutoFillLayer.set('highlightable', false);
-      plutoFillLayer.set('tooltipable', false);
-    }
+    // Remove the interactive tax lots layer group from the store
+    const destroyableTaxLotsLayerGroup = this.get('store').peekRecord('layer-group', 'tax-lots-interactive');
+    destroyableTaxLotsLayerGroup.unloadRecord();
   }
 }

--- a/app/controllers/projects/show.js
+++ b/app/controllers/projects/show.js
@@ -1,5 +1,7 @@
 import Controller from '@ember/controller';
-import { action } from '@ember-decorators/object';
+import { action, computed } from '@ember-decorators/object';
+import { service } from '@ember-decorators/service';
+
 import { EmptyFeatureCollection } from '../../models/project';
 import projectGeometryIcons from '../../utils/project-geom-icons';
 
@@ -8,6 +10,14 @@ export default class ShowProjectController extends Controller {
   EmptyFeatureCollection = EmptyFeatureCollection;
 
   projectGeometryIcons = projectGeometryIcons;
+
+  @service
+  store;
+
+  @computed()
+  get taxLotsLayerGroup() {
+    return this.get('store').peekRecord('layer-group', 'tax-lots');
+  }
 
   @action
   handleMapLoad(map) {

--- a/app/templates/components/project-geometries/modes/draw.hbs
+++ b/app/templates/components/project-geometries/modes/draw.hbs
@@ -17,7 +17,7 @@
 {{/ember-wormhole}}
 
 {{!-- We need this twice so alias it in a let and pass it down in two spots --}}
-{{#let 
+{{#let
   (component 'project-geometries/modes/draw/feature-label-form'
     selectedFeature=selectedFeature
     updateSelectedFeature=(action 'updateSelectedFeature')

--- a/app/templates/components/project-geometries/modes/lots.hbs
+++ b/app/templates/components/project-geometries/modes/lots.hbs
@@ -1,7 +1,6 @@
 {{!-- add the development-specific tax-lots layergroup --}}
-
 {{#map.labs-layers
-  layerGroups=(array taxLots)
+  layerGroups=(array interactiveTaxLots)
   onLayerClick=(action 'handleLayerClick')
   as |layers|}}
   {{#layers.tooltip as |tooltip|}}

--- a/app/templates/projects/show.hbs
+++ b/app/templates/projects/show.hbs
@@ -14,7 +14,7 @@
   <div class="grid-x">
     <div class="cell xlarge-auto">
 
-      {{#mapbox-gl
+      {{#labs-map
           id='dashboard-map'
           mapLoaded=(action 'handleMapLoad')
           initOptions=(hash
@@ -26,7 +26,8 @@
           as | map |
         }}
         {{project-geometry-renderer map=map model=model}}
-      {{/mapbox-gl}}
+        {{map.labs-layers layerGroups=(array taxLotsLayerGroup)}}
+      {{/labs-map}}
 
     </div>
     <div class="cell xlarge-shrink dashboard-controls">

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "ember-decorators": "2.1.0",
     "ember-export-application-global": "^2.0.0",
     "ember-inline-edit": "^1.1.1",
-    "ember-mapbox-composer": "0.0.21",
+    "ember-mapbox-composer": "0.2.3",
     "ember-mapbox-gl": "0.12.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-power-select": "^2.0.8",

--- a/tests/integration/components/project-geometries/modes/lots-test.js
+++ b/tests/integration/components/project-geometries/modes/lots-test.js
@@ -33,18 +33,8 @@ module('Integration | Component | project-geometries/modes/lots', function(hooks
     this.map.remove();
   });
 
-  test('it peeks and returns tax-lots', async function(assert) {
+  test('it adds the tax-lots-interactive layer', async function(assert) {
     const store = this.owner.lookup('service:store');
-
-    // push a pluto-fill layer so that the conditionals in the constructor are true
-    store.push({
-      data: [
-        {
-          type: 'layer',
-          id: 'pluto-fill',
-        },
-      ],
-    });
     const peekRecordSpy = this.sandbox.spy(store, 'peekRecord');
 
     // make dependent components happy
@@ -59,8 +49,7 @@ module('Integration | Component | project-geometries/modes/lots', function(hooks
         )}}
     `);
 
-    assert.ok(peekRecordSpy.calledTwice, 'peekRecord called once');
-    assert.equal(peekRecordSpy.firstCall.args[1], 'pluto-fill');
+    assert.equal(peekRecordSpy.firstCall.args[1], 'tax-lots-interactive');
   });
 
   test('click handler action is functional', async function(assert) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4865,7 +4865,7 @@ ember-fetch@5.1.3:
     node-fetch "^2.0.0-alpha.9"
     rollup-plugin-babel "^3.0.7"
 
-ember-font-awesome@4.0.0-rc.4, ember-font-awesome@^4.0.0-rc.2:
+ember-font-awesome@4.0.0-rc.4:
   version "4.0.0-rc.4"
   resolved "https://registry.yarnpkg.com/ember-font-awesome/-/ember-font-awesome-4.0.0-rc.4.tgz#7d4b7fbb401e21afeb7068cbb42ac8d8a84873f7"
   dependencies:
@@ -4928,11 +4928,10 @@ ember-macro-helpers@^2.0.0:
     ember-cli-test-info "^1.0.0"
     ember-weakmap "^3.0.0"
 
-ember-mapbox-composer@0.0.21:
-  version "0.0.21"
-  resolved "https://registry.yarnpkg.com/ember-mapbox-composer/-/ember-mapbox-composer-0.0.21.tgz#11aa43fdf1b43aed64118c4c63ae60d2ec3e0bb3"
+ember-mapbox-composer@0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/ember-mapbox-composer/-/ember-mapbox-composer-0.2.3.tgz#6ab2e1d5081764cd6560274a086b925b96dc4ab2"
   dependencies:
-    "@ember-decorators/babel-transforms" "^2.0.0"
     "@turf/union" "^6.0.0"
     cartobox-promises-utility "1.0.2"
     ember-auto-import "1.2.5"
@@ -4940,10 +4939,9 @@ ember-mapbox-composer@0.0.21:
     ember-cli-htmlbars "^2.0.1"
     ember-cli-htmlbars-inline-precompile "^1.0.0"
     ember-copy "1.0.0"
-    ember-decorators "2.1.0"
     ember-fetch "5.1.3"
-    ember-font-awesome "^4.0.0-rc.2"
-    ember-truth-helpers "2.0.0"
+    ember-truth-helpers "^2.0.0"
+    lodash "^4.17.11"
     mapbox-gl ">=0.47.0"
     pretender "2.0.0"
 
@@ -7870,7 +7868,7 @@ lodash@^3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.0.0, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.3.0, lodash@^4.5.1, lodash@^4.6.1, lodash@~4.17.10:
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.3.0, lodash@^4.5.1, lodash@^4.6.1, lodash@~4.17.10:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 


### PR DESCRIPTION
This PR refactors interactive tax lots so that tax lots can be visualized on all maps. 

- [x] Don't change `highlightable` and `tooltipable` on the `pluto-fill` layer when selecting lots
- [x] Instead, add a new `pluto-fill-interactive` layer when selecting lots 
- [x] Always show tax lot tooltip
- [x] Since tooltips are always showing for lots, cursor should not be a pointer unless they're clickable
- [x] Upgrades Ember Mapbox Composer (fixes tooltip bug)
- [x] Show tax lots on dashboard view

Closes #384. 
Closes #365.