### PR TITLE
Active Draw Tools

### DIFF
--- a/app/components/project-geometries/modes/draw.js
+++ b/app/components/project-geometries/modes/draw.js
@@ -32,7 +32,6 @@ export default class DrawComponent extends Component {
   // upstream set to model
   drawStateCallback() {
     const drawnFeatures = this.get('drawnFeatures');
-
     this.set('geometricProperty', drawnFeatures);
   }
 
@@ -73,6 +72,8 @@ export default class DrawComponent extends Component {
     if (selectedID && type !== 'Point' && mode === 'simple_select') {
       draw.changeMode('direct_select', { featureId: selectedID });
     }
+
+    this.set('tool', mode);
   }
 
   // Get drawn features, if they're valid
@@ -91,6 +92,14 @@ export default class DrawComponent extends Component {
       features,
     };
   }
+
+  @computed('tool')
+  get currentTool() {
+    return this.get('tool');
+  }
+
+  @argument
+  tool;
 
   // @required
   // mapbox-gl map context with draw instance
@@ -134,11 +143,13 @@ export default class DrawComponent extends Component {
   @action
   handleDrawButtonClick() {
     this.map.draw.drawInstance.changeMode('draw_polygon');
+    this.set('tool', 'draw_polygon');
   }
 
   @action
   handleAnnotation(mode) {
     this.map.draw.drawInstance.changeMode(mode);
+    this.set('tool', mode);
   }
 
   /* =================================================

--- a/app/templates/components/project-geometries/modes/draw.hbs
+++ b/app/templates/components/project-geometries/modes/draw.hbs
@@ -1,17 +1,12 @@
+{{log 'currentTool' currentTool}}
+
 {{#ember-wormhole to="draw-controls"}}
-  <button class="polygon {{if (eq drawMode 'draw_polygon') 'active'}}" {{action 'handleDrawButtonClick'}}>
+  <button class="polygon {{if (eq currentTool 'draw_polygon') 'active'}}" {{action 'handleDrawButtonClick'}}>
     {{fa-icon 'draw-polygon' size='2x' fixedWidth=true}}
     {{#ember-tooltip side='right' tooltipClassName="ember-tooltip draw-tooltip"}}
       <h5 class="small-margin-bottom">Polygon</h5>
       <p class="small-margin-bottom">Add a new shape. Complete it by clicking the final vertex a 2nd time.</p>
       <p class="no-margin text-tiny">Edit an existing shape by selecting it and dragging its vertices. Add a vertex by clicking the midpoint of a line.</p>
-    {{/ember-tooltip}}
-  </button>
-  <button class="trash" {{action 'handleTrashButtonClick'}}>
-    {{fa-icon 'trash-alt' prefix='far' size='2x' fixedWidth=true}}
-    {{#ember-tooltip side='right' tooltipClassName="ember-tooltip draw-tooltip"}}
-      <h5 class="small-margin-bottom">Trash</h5>
-      <p class="no-margin">Delete a selected shape or vertex</p>
     {{/ember-tooltip}}
   </button>
 {{/ember-wormhole}}
@@ -31,6 +26,17 @@
     )
     annotations=(component 'project-geometries/modes/draw/annotations'
       handleAnnotation=(action 'handleAnnotation')
+      currentTool=currentTool
     )
   )}}
 {{/let}}
+
+{{#ember-wormhole to="draw-controls"}}
+  <button class="trash" {{action 'handleTrashButtonClick'}}>
+    {{fa-icon 'trash-alt' prefix='far' size='2x' fixedWidth=true}}
+    {{#ember-tooltip side='right' tooltipClassName="ember-tooltip draw-tooltip"}}
+      <h5 class="small-margin-bottom">Trash</h5>
+      <p class="no-margin">Delete a selected shape or vertex</p>
+    {{/ember-tooltip}}
+  </button>
+{{/ember-wormhole}}

--- a/app/templates/components/project-geometries/modes/draw/annotations.hbs
+++ b/app/templates/components/project-geometries/modes/draw/annotations.hbs
@@ -1,5 +1,8 @@
 {{#ember-wormhole to="draw-controls"}}
-  <button class="annotation--parallel-offset" {{action handleAnnotation 'draw_annotations:linear'}}>
+  <button
+    class="annotation--parallel-offset {{if (eq currentTool 'draw_annotations:linear') 'active'}}"
+    {{action handleAnnotation 'draw_annotations:linear'}}
+  >
     <span class="fa-layers fa-2x">
       {{fa-icon 'arrows-alt-h' transform='down-4'}}
       {{fa-icon 'times' transform='shrink-9 up-3'}}
@@ -9,7 +12,10 @@
       <p class="no-margin">Annotate a parallel offset measurement</p>
     {{/ember-tooltip}}
   </button>
-  <button class="annotation--point-to-point-offset" {{action handleAnnotation 'draw_annotations:curved'}}>
+  <button
+    class="annotation--point-to-point-offset {{if (eq currentTool 'draw_annotations:curved') 'active'}}"
+    {{action handleAnnotation 'draw_annotations:curved'}}
+  >
     <span class="fa-layers fa-2x">
       {{fa-icon 'square-full' mask='circle-notch' transform='up-4'}}
       {{fa-icon 'caret-left' transform='shrink-4 left-6 rotate-45 down-4'}}
@@ -21,7 +27,10 @@
       <p class="no-margin">Annotate a point-to-point offset measurement</p>
     {{/ember-tooltip}}
   </button>
-  <button class="annotation--custom-text" {{action handleAnnotation 'draw_annotations:square'}}>
+  <button
+    class="annotation--custom-text {{if (eq currentTool 'draw_annotations:square') 'active'}}"
+    {{action handleAnnotation 'draw_annotations:square'}}
+  >
     <span class="fa-layers fa-2x">
       {{fa-icon 'square-full' mask='square-full' transform='up-1 left-1'}}
       {{fa-icon 'chevron-left' transform='rotate-45 shrink-4'}}
@@ -31,14 +40,22 @@
       <p class="no-margin">Annotate a right angle</p>
     {{/ember-tooltip}}
   </button>
-  <button class="annotation--custom-text" {{action handleAnnotation 'draw_annotations:label'}} data-test-draw-label-tool>
+  <button
+    class="annotation--custom-text {{if (eq currentTool 'draw_annotations:label') 'active'}}"
+    {{action handleAnnotation 'draw_annotations:label'}}
+    data-test-draw-label-tool
+  >
     {{fa-icon 'i-cursor' size='2x' fixedWidth=true transform='shrink-4'}}
     {{#ember-tooltip side='right' tooltipClassName="ember-tooltip draw-tooltip"}}
       <h5 class="small-margin-bottom">Text Label</h5>
       <p class="no-margin">Annotate a custom label</p>
     {{/ember-tooltip}}
-  </button> 
-  <button class="annotation--custom-text" {{action handleAnnotation 'draw_annotations:centerline'}} data-test-draw-centerline-tool>
+  </button>
+  <button
+    class="annotation--custom-text {{if (eq currentTool 'draw_annotations:centerline') 'active'}}"   
+    {{action handleAnnotation 'draw_annotations:centerline'}}
+    data-test-draw-centerline-tool
+  >
     <span class="fa-layers fa-2x">
       <span class="fa-layers-text">℄</span>
     </span>
@@ -47,44 +64,6 @@
       <p class="no-margin">Annotate a centerline</p>
     {{/ember-tooltip}}
   </button>
-  {{!--   <button class="annotation--point-to-point-offset">
-    <span class="fa-layers fa-2x">
-      {{fa-icon 'square-full' mask='circle-notch' transform='up-4'}}
-      {{fa-icon 'caret-left' transform='shrink-4 left-6 rotate-45 down-4'}}
-      {{fa-icon 'caret-right' transform='shrink-4 right-6 rotate-315 down-4'}}
-      {{fa-icon 'times' transform='shrink-9 up-3'}}
-    </span>
-    {{#ember-tooltip side='right' tooltipClassName="ember-tooltip draw-tooltip"}}
-      <h5 class="small-margin-bottom">Curved Line</h5>
-      <p class="no-margin">Annotate a point-to-point offset measurement</p>
-    {{/ember-tooltip}}
-  </button>
-  <button class="annotation--custom-text">
-    <span class="fa-layers fa-2x">
-      {{fa-icon 'square-full' mask='square-full' transform='up-1 left-1'}}
-      {{fa-icon 'chevron-left' transform='rotate-45 shrink-4'}}
-    </span>
-    {{#ember-tooltip side='right' tooltipClassName="ember-tooltip draw-tooltip"}}
-      <h5 class="small-margin-bottom">Right Angle</h5>
-      <p class="no-margin">Annotate a right angle</p>
-    {{/ember-tooltip}}
-  </button>
-  <button class="annotation--custom-text">
-    {{fa-icon 'i-cursor' size='2x' fixedWidth=true transform='shrink-4'}}
-    {{#ember-tooltip side='right' tooltipClassName="ember-tooltip draw-tooltip"}}
-      <h5 class="small-margin-bottom">Text Label</h5>
-      <p class="no-margin">Annotate a custom label</p>
-    {{/ember-tooltip}}
-  </button>
-  <button class="annotation--custom-text">
-    <span class="fa-layers fa-2x">
-      <span class="fa-layers-text">℄</span>
-    </span>
-    {{#ember-tooltip side='right' tooltipClassName="ember-tooltip draw-tooltip"}}
-      <h5 class="small-margin-bottom">Centerline</h5>
-      <p class="no-margin">Annotate a centerline</p>
-    {{/ember-tooltip}}
-  </button> --}}
 {{/ember-wormhole}}
 
 {{yield}}


### PR DESCRIPTION
This PR computes `currentTool` so we can indicate which draw tool is active. 
Also moves the trash button to the bottom of all tools. 

Closes #382.