### PR TITLE
include rezoningarea in projectGeometryBoundingBox() computed prop

### DIFF
--- a/app/components/project-geometries.js
+++ b/app/components/project-geometries.js
@@ -177,7 +177,7 @@ export default class ProjectGeometryEditComponent extends Component {
     const projectGeometryBoundingBox = this.get('model.projectGeometryBoundingBox');
     if (projectGeometryBoundingBox) {
       map.fitBounds(projectGeometryBoundingBox, {
-        padding: 150,
+        padding: 50,
         duration: 0,
       });
     }

--- a/app/models/project.js
+++ b/app/models/project.js
@@ -272,12 +272,13 @@ export default class Project extends Model {
   get projectGeometryBoundingBox() {
     // build a geojson FeatureCollection from all three project geoms
     // const featureCollections = this
-    //   .getProperties('developmentSite.proposedGeometry', 'projectArea.proposedGeometry', 'rezoningArea.proposedGeometry');
 
     const featureCollections = this
       .get('geometricProperties')
-      .filter(geometricProperty => geometricProperty.get('geometryType') === 'developmentSite'
-        || geometricProperty.get('geometryType') === 'projectArea')
+      .filter((geometricProperty) => {
+        const geometryType = geometricProperty.get('geometryType');
+        return ['developmentSite', 'projectArea', 'rezoningArea'].indexOf(geometryType) > -1;
+      })
       .mapBy('proposedGeometry');
 
     // flatten feature collections


### PR DESCRIPTION
This PR includes `rezoningArea` in the geometries used to compute `projectGeometryBoundingBox()` (used for calling `fitBounds()` on various maps.

Closes #390