### PR TITLE
revise draw control tooltips, layout

### DIFF
--- a/app/styles/modules/_m-maps.scss
+++ b/app/styles/modules/_m-maps.scss
@@ -315,9 +315,20 @@
       border-top-left-radius: 6px;
     }
 
-    &:last-child {
+    &:nth-last-child(2) {
       border-bottom-right-radius: 6px;
       border-bottom-left-radius: 6px;
+    }
+
+    &:last-child {
+      position: absolute;
+      top: 100%;
+      left: 0;
+      margin-top: 12px;
+      border-radius: 2px;
+      box-shadow:
+        0 0 0 2px $a11y-yellow,
+        0 0 0 4px rgba(0,0,0,0.1);
     }
 
     &:hover {

--- a/app/templates/components/project-geometries/modes/draw.hbs
+++ b/app/templates/components/project-geometries/modes/draw.hbs
@@ -1,12 +1,10 @@
-{{log 'currentTool' currentTool}}
-
 {{#ember-wormhole to="draw-controls"}}
   <button class="polygon {{if (eq currentTool 'draw_polygon') 'active'}}" {{action 'handleDrawButtonClick'}}>
     {{fa-icon 'draw-polygon' size='2x' fixedWidth=true}}
-    {{#ember-tooltip side='right' tooltipClassName="ember-tooltip draw-tooltip"}}
+    {{#ember-tooltip side='right' tooltipClassName="ember-tooltip draw-tooltip" popperContainer='body'}}
       <h5 class="small-margin-bottom">Polygon</h5>
-      <p class="small-margin-bottom">Add a new shape. Complete it by clicking the final vertex a 2nd time.</p>
-      <p class="no-margin text-tiny">Edit an existing shape by selecting it and dragging its vertices. Add a vertex by clicking the midpoint of a line.</p>
+      <p class="small-margin-bottom">Add a new shape. Complete it by clicking the final point a 2nd time.</p>
+      <p class="no-margin">Edit an existing shape by selecting it and dragging/deleting its points. Add a new point by clicking the midpoint of a line.</p>
     {{/ember-tooltip}}
   </button>
 {{/ember-wormhole}}
@@ -34,9 +32,9 @@
 {{#ember-wormhole to="draw-controls"}}
   <button class="trash" {{action 'handleTrashButtonClick'}}>
     {{fa-icon 'trash-alt' prefix='far' size='2x' fixedWidth=true}}
-    {{#ember-tooltip side='right' tooltipClassName="ember-tooltip draw-tooltip"}}
+    {{#ember-tooltip side='right' tooltipClassName="ember-tooltip draw-tooltip" popperContainer='body'}}
       <h5 class="small-margin-bottom">Trash</h5>
-      <p class="no-margin">Delete a selected shape or vertex</p>
+      <p class="no-margin">Delete a selected shape or point</p>
     {{/ember-tooltip}}
   </button>
 {{/ember-wormhole}}

--- a/app/templates/components/project-geometries/modes/draw/annotations.hbs
+++ b/app/templates/components/project-geometries/modes/draw/annotations.hbs
@@ -7,9 +7,9 @@
       {{fa-icon 'arrows-alt-h' transform='down-4'}}
       {{fa-icon 'times' transform='shrink-9 up-3'}}
     </span>
-    {{#ember-tooltip side='right' tooltipClassName="ember-tooltip draw-tooltip"}}
-      <h5 class="small-margin-bottom">Straight Line</h5>
-      <p class="no-margin">Annotate a parallel offset measurement</p>
+    {{#ember-tooltip side='right' tooltipClassName="ember-tooltip draw-tooltip" popperContainer='body'}}
+      <h5 class="small-margin-bottom">Parallel Measurement</h5>
+      <p class="no-margin">Dimension a zoning district boundary that is being drawn based on a parallel offset from either a street-line or a zoning district boundary</p>
     {{/ember-tooltip}}
   </button>
   <button
@@ -22,9 +22,9 @@
       {{fa-icon 'caret-right' transform='shrink-4 right-6 rotate-315 down-4'}}
       {{fa-icon 'times' transform='shrink-9 up-3'}}
     </span>
-    {{#ember-tooltip side='right' tooltipClassName="ember-tooltip draw-tooltip"}}
-      <h5 class="small-margin-bottom">Curved Line</h5>
-      <p class="no-margin">Annotate a point-to-point offset measurement</p>
+    {{#ember-tooltip side='right' tooltipClassName="ember-tooltip draw-tooltip" popperContainer='body'}}
+      <h5 class="small-margin-bottom">Point-to-point Measurement</h5>
+      <p class="no-margin">Dimension a zoning district boundary that is being drawn based on a point-to-point offset</p>
     {{/ember-tooltip}}
   </button>
   <button
@@ -35,9 +35,10 @@
       {{fa-icon 'square-full' mask='square-full' transform='up-1 left-1'}}
       {{fa-icon 'chevron-left' transform='rotate-45 shrink-4'}}
     </span>
-    {{#ember-tooltip side='right' tooltipClassName="ember-tooltip draw-tooltip"}}
+    {{#ember-tooltip side='right' tooltipClassName="ember-tooltip draw-tooltip" popperContainer='body'}}
       <h5 class="small-margin-bottom">Right Angle</h5>
-      <p class="no-margin">Annotate a right angle</p>
+      <p class="small-margin-bottom">Annotate a right angle for a zoning district boundary that is being drawing based on a point-to-point offset.</p>
+      <p class="no-margin">Place the first point on the vertex of the angle. Place the second point inside the angle at 45º. Drag to adjust the size and position.</p>
     {{/ember-tooltip}}
   </button>
   <button
@@ -46,22 +47,22 @@
     data-test-draw-label-tool
   >
     {{fa-icon 'i-cursor' size='2x' fixedWidth=true transform='shrink-4'}}
-    {{#ember-tooltip side='right' tooltipClassName="ember-tooltip draw-tooltip"}}
-      <h5 class="small-margin-bottom">Text Label</h5>
-      <p class="no-margin">Annotate a custom label</p>
+    {{#ember-tooltip side='right' tooltipClassName="ember-tooltip draw-tooltip" popperContainer='body'}}
+      <h5 class="small-margin-bottom">Text</h5>
+      <p class="no-margin">Add a custom label</p>
     {{/ember-tooltip}}
   </button>
   <button
-    class="annotation--custom-text {{if (eq currentTool 'draw_annotations:centerline') 'active'}}"   
+    class="annotation--custom-text {{if (eq currentTool 'draw_annotations:centerline') 'active'}}"
     {{action handleAnnotation 'draw_annotations:centerline'}}
     data-test-draw-centerline-tool
   >
     <span class="fa-layers fa-2x">
       <span class="fa-layers-text">℄</span>
     </span>
-    {{#ember-tooltip side='right' tooltipClassName="ember-tooltip draw-tooltip"}}
+    {{#ember-tooltip side='right' tooltipClassName="ember-tooltip draw-tooltip" popperContainer='body'}}
       <h5 class="small-margin-bottom">Centerline</h5>
-      <p class="no-margin">Annotate a centerline</p>
+      <p class="no-margin">Annotate a proposed zoning district boundary that runs midway between two streets</p>
     {{/ember-tooltip}}
   </button>
 {{/ember-wormhole}}


### PR DESCRIPTION
This PR updates the text in the draw controls' tooltips and visually separates the trash button. 

Closes #394. 

![image](https://user-images.githubusercontent.com/409279/53192389-582e0900-35dc-11e9-9aea-a6892af95bec.png)
