### PR TITLE
381: Round all line measurement annotation labels to nearest 5'

### DIFF
--- a/app/utils/mapbox-gl-draw/annotations/mode.js
+++ b/app/utils/mapbox-gl-draw/annotations/mode.js
@@ -1,6 +1,9 @@
 import length from '@turf/length';
 import MapboxDraw from '@mapbox/mapbox-gl-draw';
 
+export function roundLength(len) {
+  return Math.round(len / 5) * 5;
+}
 function createVertex(parentId, coordinates, path, selected) {
   return {
     type: 'Feature',
@@ -87,7 +90,7 @@ MeasurementMode.onStop = function(state) {
 
 MeasurementMode.toDisplayFeatures = function(state, geojson, display) {
   // calculate label, append to properties
-  const label = `${(length(geojson) * 3280.84).toFixed(0)} ft`; // km to feet
+  const label = `${roundLength(length(geojson) * 3280.84)} ft`; // km to feet
   state.line.properties.label = label;
   geojson.properties.label = label;
 

--- a/tests/unit/utils/mapbox-gl-draw/annotations/mode-test.js
+++ b/tests/unit/utils/mapbox-gl-draw/annotations/mode-test.js
@@ -1,10 +1,33 @@
-import mapboxGlDrawAnnotationMode from 'labs-applicant-maps/utils/mapbox-gl-draw/annotations/mode';
-import { module, skip } from 'qunit';
+import { roundLength } from 'labs-applicant-maps/utils/mapbox-gl-draw/annotations/mode';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-module('Unit | Utility | mapbox-gl-draw/annotation-mode', function() {
-  // Replace this with your real tests.
-  skip('it works', function(assert) {
-    const result = mapboxGlDrawAnnotationMode();
-    assert.ok(result);
+module('Unit | Utility | mapbox-gl-draw/annotation-mode', function(hooks) {
+  setupTest(hooks);
+  test('it rounds lengths as expected', function (assert) {
+    const dataProvider = [
+      { raw: 0, rounded: 0 },
+      { raw: 1, rounded: 0 },
+      { raw: 2, rounded: 0 },
+      { raw: 3, rounded: 5 },
+      { raw: 4, rounded: 5 },
+      { raw: 5, rounded: 5 },
+      { raw: 6, rounded: 5 },
+      { raw: 7, rounded: 5 },
+      { raw: 8, rounded: 10 },
+      { raw: 9, rounded: 10 },
+      { raw: 12.3, rounded: 10 },
+      { raw: 123.4, rounded: 125 },
+      { raw: 1234.5, rounded: 1235 },
+      { raw: 12345.6, rounded: 12345 },
+      { raw: 123456.7, rounded: 123455 },
+      { raw: 1234567.8, rounded: 1234570 },
+      { raw: 12345678.9, rounded: 12345680 },
+    ];
+
+    dataProvider.forEach(({ raw, rounded }) => {
+      const result = roundLength(raw);
+      assert.equal(result, rounded);
+    });
   });
 });


### PR DESCRIPTION
closes #381 

Not sure this is necessarily how we want the rounding to work. Can easily update to follow different logic. Please weigh in if you think this should change :) 