### PR TITLE
make annotation arrows ignore placement and allow overlap

### DIFF
--- a/app/utils/mapbox-gl-draw/annotations/generate-curvature.js
+++ b/app/utils/mapbox-gl-draw/annotations/generate-curvature.js
@@ -25,6 +25,8 @@ const getArrowLayers = (lineFeature, id, annotationType) => {
     },
     'icon-anchor': 'top',
     'icon-rotation-alignment': 'map',
+    'icon-allow-overlap': true,
+    'icon-ignore-placement': true,
   };
 
   const startArrowLayer = {
@@ -186,6 +188,8 @@ const buildLineLayers = function(rawLineFeature, annotationType) {
       'text-justify': 'center',
       'text-anchor': 'center',
       'text-size': 12,
+      'text-allow-overlap': true,
+      'text-ignore-placement': true,
     },
   };
 
@@ -228,6 +232,8 @@ export default function(...args) {
         'text-justify': 'center',
         'text-anchor': 'center',
         'text-size': 12,
+        'text-allow-overlap': true,
+        'text-ignore-placement': true,
       },
     }];
   }
@@ -250,6 +256,8 @@ export default function(...args) {
         'text-justify': 'center',
         'text-anchor': 'center',
         'text-size': 16,
+        'text-allow-overlap': true,
+        'text-ignore-placement': true,
       },
     }];
   }

--- a/app/utils/mapbox-gl-draw/annotations/styles.js
+++ b/app/utils/mapbox-gl-draw/annotations/styles.js
@@ -31,6 +31,8 @@ export default [
       ],
       'text-justify': 'center',
       'text-anchor': 'center',
+      'text-allow-overlap': true,
+      'text-ignore-placement': true,
     },
   },
 
@@ -46,6 +48,8 @@ export default [
         property: 'rotation',
       },
       'icon-anchor': 'top',
+      'icon-allow-overlap': true,
+      'icon-ignore-placement': true,
     },
   },
 
@@ -83,6 +87,8 @@ export default [
         0,
       ],
       'text-size': 22,
+      'text-allow-overlap': true,
+      'text-ignore-placement': true,
     },
     paint: {
       'text-color': 'rgba(0, 0, 0, 1)',


### PR DESCRIPTION
Closes #367.
Closes #377.