### PR TITLE
433: tweak default zoom levels

### DIFF
--- a/app/components/project-geometries.js
+++ b/app/components/project-geometries.js
@@ -177,7 +177,7 @@ export default class ProjectGeometryEditComponent extends Component {
     const projectGeometryBoundingBox = this.get('model.projectGeometryBoundingBox');
     if (projectGeometryBoundingBox) {
       map.fitBounds(projectGeometryBoundingBox, {
-        padding: 50,
+        padding: 120,
         duration: 0,
       });
     }

--- a/app/components/search-handler.js
+++ b/app/components/search-handler.js
@@ -50,7 +50,7 @@ export default class SearchHandlerComponent extends Component {
     const { map: { mapInstance } } = this;
 
     this.set('geocodedFeature', { type: 'geojson', data: geometry });
-    mapInstance.flyTo({ center: coordinates, zoom: 16 });
+    mapInstance.flyTo({ center: coordinates, zoom: 18 });
   }
 
   // search


### PR DESCRIPTION
Increases default zoom for address search; decreases zoom (via fitBounds() parameter {padding}) when loading geometry edit views 

closes #433