### PR TITLE
404 Update data citations for pluto to reflect version

### DIFF
--- a/app/templates/components/map-form.hbs
+++ b/app/templates/components/map-form.hbs
@@ -178,7 +178,7 @@
                   <br />
                   {{#each mapConfiguration.sources as |source index|}}
                     {{~if index ';'}}
-                    <strong>{{source.id}}</strong>
+                    {{source.id}}
                     {{#if (eq source.id 'pluto')}}
                       {{source.meta.description}}
                     {{/if}}

--- a/app/templates/components/map-form.hbs
+++ b/app/templates/components/map-form.hbs
@@ -178,7 +178,10 @@
                   <br />
                   {{#each mapConfiguration.sources as |source index|}}
                     {{~if index ';'}}
-                    {{source.id}}
+                    <strong>{{source.id}}</strong>
+                    {{#if (eq source.id 'pluto')}}
+                      {{source.meta.description}}
+                    {{/if}}
                     {{if source.meta.updated_at (concat '(' source.meta.updated_at ')')~}}
                   {{/each}}
                 </div>


### PR DESCRIPTION
Edited data citations on Area Map to add `meta.description` for Pluto to show version number. 

Closes #404 