### PR TITLE
327: tests for zoning query utils

### DIFF
--- a/tests/unit/utils/queries/intersecting-zoning-query-test.js
+++ b/tests/unit/utils/queries/intersecting-zoning-query-test.js
@@ -7,15 +7,16 @@ module('Unit | Utility | queries/intersecting-zoning-query', function(hooks) {
   setupTest(hooks);
   setupMirage(hooks);
 
-  // Replace this with your real tests.
-  test('it works', async function(assert) {
+  test('returns a feature collection when development site passed into intersecting zoning query', async function(assert) {
     this.server.createList('project', 1);
+
     const store = this.owner.lookup('service:store');
     const model = await store.findRecord('project', 1, { include: 'geometric-properties' });
-
-    const result = queriesIntersectingZoningQuery(
+    const result = await queriesIntersectingZoningQuery(
       model.get('developmentSite'),
     );
+
     assert.ok(result);
+    assert.equal(result.type, 'FeatureCollection'); // assert that type property in result object is FeatureCollection
   });
 });

--- a/tests/unit/utils/queries/proposed-commercial-overlays-query-test.js
+++ b/tests/unit/utils/queries/proposed-commercial-overlays-query-test.js
@@ -7,15 +7,16 @@ module('Unit | Utility | queries/proposed-commercial-overlays-query', function(h
   setupTest(hooks);
   setupMirage(hooks);
 
-  // Replace this with your real tests.
-  test('it works', async function(assert) {
+  test('returns a feature collection when development site passed into commercial overlays query', async function(assert) {
     this.server.createList('project', 1);
 
     const store = this.owner.lookup('service:store');
     const model = await store.findRecord('project', 1, { include: 'geometric-properties' });
-    const result = queriesProposedCommercialOverlaysQuery(
+    const result = await queriesProposedCommercialOverlaysQuery(
       model.get('developmentSite'),
     );
+
     assert.ok(result);
+    assert.equal(result.type, 'FeatureCollection'); // assert that type property in result object is FeatureCollection
   });
 });

--- a/tests/unit/utils/queries/proposed-special-districts-query-test.js
+++ b/tests/unit/utils/queries/proposed-special-districts-query-test.js
@@ -7,15 +7,16 @@ module('Unit | Utility | queries/proposed-special-districts-query', function(hoo
   setupTest(hooks);
   setupMirage(hooks);
 
-  // Replace this with your real tests.
-  test('it works', async function(assert) {
+  test('returns a feature collection when development site passed into special districts query', async function(assert) {
     this.server.createList('project', 1);
 
     const store = this.owner.lookup('service:store');
     const model = await store.findRecord('project', 1, { include: 'geometric-properties' });
-    const result = queriesProposedSpecialDistrictsQuery(
+    const result = await queriesProposedSpecialDistrictsQuery(
       model.get('developmentSite'),
     );
+
     assert.ok(result);
+    assert.equal(result.type, 'FeatureCollection'); // assert that type property in result object is FeatureCollection
   });
 });


### PR DESCRIPTION
Unit tests for these utils: 

- `intersecting-zoning-query`
- `proposed-commercial-overlays-query`
- `proposed-special-districts-query`

Testing that a feature collection is returned when pass `developmentSite` into query

Part of #327 