### PR TITLE
446: Recenter inset-map on areamap layout update

### DIFF
--- a/app/components/map-form/inset-map.js
+++ b/app/components/map-form/inset-map.js
@@ -1,6 +1,6 @@
 import Component from '@ember/component';
 import { argument } from '@ember-decorators/argument';
-import { action } from '@ember-decorators/object';
+import { action, observes } from '@ember-decorators/object';
 import { classNames } from '@ember-decorators/component';
 import turfBbox from '@turf/bbox';
 import turfBuffer from '@turf/buffer';
@@ -20,5 +20,20 @@ class InsetMap extends Component {
     map.fitBounds(turfBbox(turfBuffer(bounds, 13)), {
       duration: 0,
     });
+  }
+
+  @observes('boundsPolygon')
+  resize() {
+    const map = this.get('mapInstance');
+    // just incase this gets triggered unexpectedly before the map has been loaded,
+    // only attempt to re-render if map exists
+    if (map) {
+      this.resizeMap(map);
+    }
+  }
+
+  // wrapped for test-ability
+  resizeMap = function(map) {
+    map.resize();
   }
 }

--- a/tests/integration/components/map-form/inset-map-test.js
+++ b/tests/integration/components/map-form/inset-map-test.js
@@ -1,26 +1,33 @@
-import { module, skip } from 'qunit';
+import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import setupMapMocks from 'labs-applicant-maps/tests/helpers/setup-map-mocks';
 
 module('Integration | Component | inset-map', function(hooks) {
   setupRenderingTest(hooks);
+  setupMapMocks(hooks);
 
-  skip('it renders', async function(assert) {
+  test('it contains a mapboxgl-map div', async function(assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
-    await render(hbs`{{map-form/inset-map}}`);
+    this.set('boundsPolygon', {
+      type: 'Polygon',
+      coordinates: [[
+        [0, 0],
+        [10, 0],
+        [10, 10],
+        [0, 10],
+        [0, 0],
+      ]],
+    });
 
-    assert.equal(this.element.textContent.trim(), 'Missing Mapbox GL JS CSS');
+    await render(hbs`{{map-form/inset-map boundsPolygon=this.boundsPolygon}}`);
 
-    // Template block usage:
-    await render(hbs`
-      {{#map-form/inset-map}}
-        Missing Mapbox GL JS CSS
-      {{/map-form/inset-map}}
-    `);
-
-    assert.equal(this.element.textContent.trim(), 'Missing Mapbox GL JS CSS');
+    // assert inset map is rendered with a mapbox GL 'inset-map' div
+    const insetMap = find('#inset-map');
+    assert.ok(insetMap);
+    assert.ok(insetMap.className.split(' ').includes('mapboxgl-map'));
   });
 });

--- a/tests/unit/components/map-form/inset-map-test.js
+++ b/tests/unit/components/map-form/inset-map-test.js
@@ -1,0 +1,67 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { fake } from 'sinon';
+import createMap from 'labs-applicant-maps/tests/helpers/create-map';
+
+module('Unit | Component | map-form/inset-map', function(hooks) {
+  setupTest(hooks);
+
+  test('it does not attempt to resize the map if no mapInstance exists', function(assert) {
+    const component = this.owner.factoryFor('component:map-form/inset-map').create();
+
+    // set up mocks
+    const resizeMap = fake();
+    component.resizeMap = resizeMap;
+
+    // update boundsPolygon (triggers resize observer -- assume this "just works" b/c it is ember feature)
+    component.set('boundsPolygon', {
+      type: 'Polygon',
+      coordinates: [[
+        [0, 0],
+        [10, 0],
+        [10, 10],
+        [0, 10],
+        [0, 0],
+      ]],
+    });
+
+    // because map object not set in component, resizeMap should not be called
+    assert.equal(resizeMap.callCount, 0);
+  });
+
+  test('it does resize the map if mapInstance exists', async function(assert) {
+    const component = this.owner.factoryFor('component:map-form/inset-map').create();
+
+    // set up mocks
+    const resizeMap = fake();
+    component.resizeMap = resizeMap;
+
+    // set up component with initial value for boundsPolygon and map
+    component.set('boundsPolygon', {
+      type: 'Polygon',
+      coordinates: [[
+        [0, 0],
+        [10, 0],
+        [10, 10],
+        [0, 10],
+        [0, 0],
+      ]],
+    });
+    const map = await createMap();
+    component.handleMapLoad(map);
+
+    // update boundsPolygon (triggers resize observer -- assume this "just works" b/c it is ember feature)
+    component.set('boundsPolygon', {
+      type: 'Polygon',
+      coordinates: [[
+        [0, 0],
+        [10, 0],
+        [0, 10],
+        [0, 0],
+      ]],
+    });
+
+    // because we have set the map, resizeMap should be called when boundsPolygon is updated
+    assert.equal(resizeMap.callCount, 1);
+  });
+});


### PR DESCRIPTION
when boundsPolygon from map-form is updated (i.e. when areamap display
is updated), the inset-map should redraw to remain centered around
boundsPolygon

closes #446 