### PR TITLE
393 - Text Annotation Font Options

### DIFF
--- a/app/components/project-geometries/modes/draw.js
+++ b/app/components/project-geometries/modes/draw.js
@@ -156,11 +156,12 @@ export default class DrawComponent extends Component {
   }
 
   @action
-  updateSelectedFeature(label) {
+  updateSelectedFeature(property, value) {
     const { draw: { drawInstance: draw } } = this.get('map');
     const { features: [firstFeature] } = this.get('selectedFeature');
 
-    draw.setFeatureProperty(firstFeature.id, 'label', label);
+
+    draw.setFeatureProperty(firstFeature.id, property, value);
 
     // this triggers an update that renders the new label as mutated above to show up in the selected feature
     // see https://github.com/mapbox/mapbox-gl-draw/blob/master/docs/API.md#events

--- a/app/components/project-geometries/modes/draw/feature-label-form.js
+++ b/app/components/project-geometries/modes/draw/feature-label-form.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { action } from '@ember-decorators/object';
+import { action, observes } from '@ember-decorators/object';
 import { argument } from '@ember-decorators/argument';
 import { alias } from '@ember-decorators/object/computed';
 
@@ -18,13 +18,50 @@ export default class FeatureLabelFormComponent extends Component {
   @argument
   options=null;
 
+  isBold = false;
+
+  isLarge = false;
+
+  @observes('selectedFeature')
+  selectedFeatureUpdated() {
+    this.set('isBold', false);
+    this.set('isLarge', false);
+  }
+
   @alias('selectedFeature.features.firstObject.properties.label')
   label;
+
+  @alias('selectedFeature.features.firstObject.geometry.type')
+  geomType;
 
   @action
   handleSelectChange(newLabel) {
     this.set('label', newLabel);
-    this.updateSelectedFeature(newLabel);
+    this.updateSelectedFeature('label', newLabel);
+    if (this.get('geomType') === 'Polygon') {
+      this.updateSelectedFeature('textFont', 'bold');
+    }
     this.drawStateCallback();
+  }
+
+  @action
+  toggleSize() {
+    const shouldMakeSmall = this.get('isLarge');
+
+    const textSize = shouldMakeSmall ? 'default' : 'large';
+    this.updateSelectedFeature('textSize', textSize);
+
+    this.set('isLarge', !shouldMakeSmall);
+  }
+
+  @action
+  toggleWeight() {
+    const shouldMakeLight = this.get('isBold');
+
+
+    const textFont = shouldMakeLight ? 'default' : 'bold';
+    this.updateSelectedFeature('textFont', textFont);
+
+    this.set('isBold', !shouldMakeLight);
   }
 }

--- a/app/components/project-geometries/types/special-purpose-districts.js
+++ b/app/components/project-geometries/types/special-purpose-districts.js
@@ -19,7 +19,13 @@ export const specialPurposeDistrictsLabelsLayer = {
   layout: {
     'symbol-placement': 'point',
     'text-field': '{label}',
-    'text-size': 12,
+    'text-size': 16,
+    'text-font': [
+      'match',
+      ['get', 'textFont'],
+      'bold', ['literal', ['Open Sans Bold', 'Arial Unicode MS Bold']],
+      ['literal', ['Open Sans Regular', 'Arial Unicode MS Regular']],
+    ],
     visibility: 'visible',
     'symbol-avoid-edges': false,
     'text-offset': [

--- a/app/components/project-geometries/types/underlying-zoning.js
+++ b/app/components/project-geometries/types/underlying-zoning.js
@@ -20,6 +20,11 @@ export const underlyingZoningLabelsLayer = {
     'symbol-placement': 'line',
     'text-field': '{label}',
     'text-size': 16,
+    'text-font': [
+      'match', ['get', 'textFont'], 'bold', // condition
+      ['literal', ['Open Sans Bold', 'Arial Unicode MS Bold']], // match
+      ['literal', ['Open Sans Regular', 'Arial Unicode MS Regular']], // default
+    ],
     visibility: 'visible',
     'symbol-avoid-edges': false,
     'text-offset': [

--- a/app/styles/modules/_m-maps.scss
+++ b/app/styles/modules/_m-maps.scss
@@ -354,28 +354,13 @@
   position: absolute;
   top: 110px;
   left: 72px;
-  // bottom: 50px;
-  // left: 50%;
-  // transform: translateX(-50%);
   z-index: 1;
   background-color: $a11y-yellow;
   border: 4px solid $a11y-yellow;
   border-radius: 4px;
   box-shadow: 0 0 0 2px rgba(0,0,0,0.1);
   width: 15rem;
-
-  .input-group {
-    margin: 0;
-  }
-
-  .input-group-label {
-    background-color: $a11y-yellow;
-    border-color: transparent;
-  }
-
-  .input-group-field {
-    width: 9rem;
-  }
+  padding: 4px 4px 0;
 }
 
 

--- a/app/templates/components/project-geometries/modes/draw/feature-label-form.hbs
+++ b/app/templates/components/project-geometries/modes/draw/feature-label-form.hbs
@@ -1,27 +1,43 @@
 {{#if (not (is-empty selectedFeature))}}
   <div class="selected-feature-form">
-    <div class="input-group">
-      <span class="input-group-label text-small">{{fa-icon 'tag' transform='grow-6'}}</span>
-      {{!-- if an array of values was passed in as the 'options' property, use power select --}}
-      {{#if (and options (not (get selectedFeature.features.firstObject.properties 'meta:mode')))}}
-        <div class="input-group-field">
-          {{#power-select
-            options=options
-            selected=label
-            onchange=(action "handleSelectChange")
-          as |selectedLabel|}}
-            {{selectedLabel}}
-          {{/power-select}}
-        </div>
-      {{else}}
-        {{input
-          data-test-feature-label-form
-          type="text"
-          class="input-group-field"
-          value=label
-          key-up=(action 'handleSelectChange')
-        }}
-      {{/if}}
-    </div>
+
+    <h6>Edit Label</h6>
+
+    {{!-- if an array of values was passed in as the 'options' property, use power select --}}
+    {{#if (and options (not (get selectedFeature.features.firstObject.properties 'meta:mode')))}}
+      {{#power-select
+        options=options
+        selected=label
+        onchange=(action "handleSelectChange")
+      as |selectedLabel|}}
+        {{selectedLabel}}
+      {{/power-select}}
+    {{else}}
+      {{input
+        data-test-feature-label-form
+        type="text"
+        value=label
+        class="no-margin"
+        key-up=(action 'handleSelectChange')
+      }}
+    {{/if}}
+
+    {{#unless (eq geomType 'Polygon') }}
+    <p class="text-right no-margin">
+      <button data-test-large-button onClick={{ action 'toggleSize' }} class="button small no-margin clear">
+        <span class="fa-layers">
+          {{fa-icon 'square' fixedWidth=true class=(if isLarge 'orange-dark' 'white')}}
+          {{fa-icon 'check-square' fixedWidth=true class="white"}}
+        </span>&nbsp; Large
+      </button>
+      <button data-test-bold-button onClick={{ action 'toggleWeight' }} class="button small no-margin clear">
+        <span class="fa-layers">
+          {{fa-icon 'square' fixedWidth=true class=(if isBold 'orange-dark' 'white')}}
+          {{fa-icon 'check-square' fixedWidth=true class="white"}}
+        </span>&nbsp; Bold
+      </button>
+    </p>
+    {{/unless}}
+
   </div>
 {{/if}}

--- a/app/utils/mapbox-gl-draw/annotations/generate-curvature.js
+++ b/app/utils/mapbox-gl-draw/annotations/generate-curvature.js
@@ -231,7 +231,18 @@ export default function(...args) {
         ],
         'text-justify': 'center',
         'text-anchor': 'center',
-        'text-size': 12,
+        'text-size': [
+          'match',
+          ['get', 'textSize'],
+          'large', 16,
+          12,
+        ],
+        'text-font': [
+          'match', ['get', 'textFont'], 'bold', // condition
+          ['literal', ['Open Sans Bold', 'Arial Unicode MS Bold']], // match
+          ['literal', ['Open Sans Regular', 'Arial Unicode MS Regular']], // default
+        ],
+
         'text-allow-overlap': true,
         'text-ignore-placement': true,
       },


### PR DESCRIPTION
This PR will address #393 by allowing users to adjust the font size and weight of text annotations. 

I've stubbed in this UI: 

![image](https://user-images.githubusercontent.com/409279/53602634-66040100-3b7d-11e9-909e-9b34f3d9be9b.png)

Need to: 
- [ ] add actions to "Large" button and "Bold" button that toggle font state
- [ ] replace hardcoded booleans with a real conditions to indicate state of buttons
- [ ] save `large` and `bold` to the label
- [ ] use `large` and `bold` to style the layer(s) accordingly
- [ ] make sure two sizes and weights of text labels match polygon styles

@Taylor, you were doing some work on styling labels. Would you like to pair on finishing this?

closes #393