### PR TITLE
417: Forces user to add a polygon label

### DIFF
--- a/app/components/mapbox-gl-draw.js
+++ b/app/components/mapbox-gl-draw.js
@@ -6,7 +6,7 @@ import { next } from '@ember/runloop';
 import { service } from '@ember-decorators/service';
 import { action, computed } from '@ember-decorators/object';
 import { setProperties } from '@ember/object';
-import AnnotationsMode, { annotatable } from 'labs-applicant-maps/utils/mapbox-gl-draw/annotations/mode';
+import AnnotationsMode, { DirectSelect_RequiresPolygonLabelMode, annotatable } from 'labs-applicant-maps/utils/mapbox-gl-draw/annotations/mode';
 import AnnotationsStyles from 'labs-applicant-maps/utils/mapbox-gl-draw/annotations/styles';
 import isEmpty from 'labs-applicant-maps/utils/is-empty';
 
@@ -36,14 +36,15 @@ export const DefaultDraw = MapboxDraw.bind(null, {
     'draw_annotations:centerline': AnnotationsDrawPointMode,
     // duplicate mode with distinct name  to avoid `skipToDirectSelect` trigger when we switch to simple_select for delete
     simple_select_delete: MapboxDraw.modes.simple_select,
-  }, MapboxDraw.modes),
+  },
+  MapboxDraw.modes,
+  { direct_select: DirectSelect_RequiresPolygonLabelMode }),
   styles,
 });
 
 export default class MapboxGlDraw extends Component {
   constructor(...args) {
     super(...args);
-
     const {
       draw = new DefaultDraw(),
     } = this.get('map');

--- a/app/components/project-geometries/modes/draw/feature-label-form.js
+++ b/app/components/project-geometries/modes/draw/feature-label-form.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { action, observes } from '@ember-decorators/object';
+import { action, observes, computed } from '@ember-decorators/object';
 import { argument } from '@ember-decorators/argument';
 import { alias } from '@ember-decorators/object/computed';
 
@@ -14,6 +14,17 @@ export default class FeatureLabelFormComponent extends Component {
 
   @argument
   drawStateCallback() {}
+
+  /*
+   * Boolean flag computed from selectedFeature provided by calling draw/geom-type component
+   * Used to optionally display the label form in "invalid" style
+   * to indicate to the user that a label is required. As mode-switching is invalid w/out label,
+   * user needs visual cue to know why they're stuck.
+   */
+  @computed('selectedFeature.features.@each.missingLabel')
+  get isSelectedFeatureFormInvalid() {
+    return this.get('selectedFeature.features')[0].missingLabel === true;
+  }
 
   @argument
   options=null;

--- a/app/models/geometric-property.js
+++ b/app/models/geometric-property.js
@@ -52,6 +52,26 @@ export const GEOMETRY_TYPES = [
   'rezoningArea',
 ];
 
+/*
+ * Checks that, if there are new polygons of given geometricProperty type,
+ * all of them have labels
+ */
+export function newPolygonsHaveLabels(geometricPropertyForType) {
+  const [
+    _initial, // eslint-disable-line
+    proposed,
+  ] = geometricPropertyForType.changedAttributes().proposedGeometry || [];
+
+  if (proposed) {
+    const polygonWithoutLabel = proposed.features.find(feature => !feature.properties.label);
+
+    if (polygonWithoutLabel) return false;
+  }
+
+  return true;
+}
+
+
 // returns true or false based on whether the change to the geometric
 // property was "meaningful", or a change to the `proposedGeometry` attr
 // that is:
@@ -71,6 +91,7 @@ export function isMeaningfulChange(geometricPropertyForType /* model */) {
   // "initial" means whatever is currently proposed. If it's _not_ empty and
   // the geometric property doesn't have something canonical to compare,
   // it should return true
+
   if (!isEmpty(initial) && !geometricPropertyForType.get('hasCanonical')) return true;
 
   // only apply this check if this is a canonical geometric prop
@@ -114,7 +135,16 @@ export default class extends Model {
 
   @computed('canonical', 'proposedGeometry', 'annotations', 'data')
   get isReadyToProceed() {
-    return isMeaningfulChange(this);
+    let ready = isMeaningfulChange(this);
+
+    /*
+     * Check that proposed polygons have labels for rezoning geometries.
+     * NOT enforced for development site or project area
+     */
+    if (!['developmentSite', 'projectArea'].includes(this.geometryType)) {
+      ready = ready && newPolygonsHaveLabels(this);
+    }
+    return ready;
   }
 
   @computed('canonical', 'proposedGeometry', 'hasDirtyAttributes')

--- a/app/styles/modules/_m-maps.scss
+++ b/app/styles/modules/_m-maps.scss
@@ -361,6 +361,23 @@
   box-shadow: 0 0 0 2px rgba(0,0,0,0.1);
   width: 15rem;
   padding: 4px 4px 0;
+
+  &.invalid {
+    box-shadow: 0 0 0 2px $red;
+  }
+
+  .input-group {
+    margin: 0;
+  }
+
+  .input-group-label {
+    background-color: $a11y-yellow;
+    border-color: transparent;
+  }
+
+  .input-group-field {
+    width: 9rem;
+  }
 }
 
 

--- a/app/templates/components/project-geometries/modes/draw/feature-label-form.hbs
+++ b/app/templates/components/project-geometries/modes/draw/feature-label-form.hbs
@@ -1,5 +1,5 @@
 {{#if (not (is-empty selectedFeature))}}
-  <div class="selected-feature-form">
+  <div class="selected-feature-form {{if isSelectedFeatureFormInvalid 'invalid' }}">
 
     <h6>Edit Label</h6>
 

--- a/tests/acceptance/back-button-works-test.js
+++ b/tests/acceptance/back-button-works-test.js
@@ -42,7 +42,7 @@ module('Acceptance | back button works', function(hooks) {
     this.owner.register('component:project-geometries/modes/draw', DrawMode.extend({
       'data-test-draw-mock': true,
       click() {
-        const randomFeatures = randomPolygon(1);
+        const randomFeatures = randomPolygon(1, true);
         this.set('geometricProperty', randomFeatures);
       },
     }));

--- a/tests/acceptance/polygon-labels-required-for-progress-test.js
+++ b/tests/acceptance/polygon-labels-required-for-progress-test.js
@@ -1,0 +1,113 @@
+import { module, test } from 'qunit';
+import {
+  visit,
+  currentURL,
+  click,
+  fillIn,
+} from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { faker } from 'ember-cli-mirage';
+import random from 'labs-applicant-maps/tests/helpers/random-geometry';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import setupMapMocks from 'labs-applicant-maps/tests/helpers/setup-map-mocks';
+import LabsLayers from 'labs-applicant-maps/components/labs-layers';
+import DrawMode from 'labs-applicant-maps/components/project-geometries/modes/draw';
+
+const { randomPolygon } = random;
+
+module('Acceptance | polygon labels required for progress', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  setupMapMocks(hooks);
+
+  hooks.beforeEach(async function() {
+    this.server.createList('layer-group', 10);
+    this.server.create('layer-group', { id: 'tax-lots' });
+
+    let onLayerClick;
+    this.owner.register('component:labs-layers', LabsLayers.extend({
+      init(...args) {
+        this._super(...args);
+
+        onLayerClick = this.get('onLayerClick');
+      },
+      'data-test-labs-layers': true,
+      click() {
+        const randomFeature = randomPolygon(1).features[0];
+        randomFeature.properties.bbl = faker.random.uuid();
+        onLayerClick(randomFeature);
+      },
+    }));
+
+    this.owner.register('component:project-geometries/modes/draw', DrawMode.extend({
+      'data-test-draw-mock': true,
+      // use shiftKey as a switch for drawing polygon with / without label
+      click({ shiftKey }) {
+        let randomFeatures = randomPolygon(1);
+        if (shiftKey) {
+          randomFeatures = randomPolygon(1, true);
+        }
+        this.set('geometricProperty', randomFeatures);
+      },
+    }));
+  });
+
+
+  test('cannot save polygon without label', async function(assert) {
+    // set up project and select to do rezoning edits
+    await visit('/');
+    await click('[data-test-get-started]');
+    await fillIn('[data-test-new-project-project-name]', 'Mulholland Drive');
+    await click('[data-test-create-new-project]');
+    await click('[data-test-select-lots]');
+    await click('[data-test-labs-layers]');
+    await click('[data-test-project-geometry-save]');
+    await click('[data-test-project-area-yes]');
+    await click('[data-test-project-area-select-lots]');
+    await click('[data-test-labs-layers]');
+    await click('[data-test-project-geometry-save]');
+    await click('[data-test-rezoning-yes]');
+    await click('[data-test-rezoning-underlying-zoning-yes]');
+    await click('[data-test-rezoning-commercial-overlays-yes]');
+    await click('[data-test-rezoning-special-purpose-districts-yes]');
+    await click('[data-test-alter-zoning]');
+
+    // draw rezoning polygon w/out label
+    await click('[data-test-draw-mock]');
+
+    // click save button (should fail)
+    await click('[data-test-project-geometry-save]');
+
+    // assert save was a noop (we're still editing underlying zoning
+    assert.equal(currentURL(), '/projects/1/edit/geometry-edit?mode=draw&type=underlying-zoning');
+  });
+
+  test('can save polygon with label', async function(assert) {
+    // set up project and select to do rezoning edits
+    await visit('/');
+    await click('[data-test-get-started]');
+    await fillIn('[data-test-new-project-project-name]', 'Mulholland Drive');
+    await click('[data-test-create-new-project]');
+    await click('[data-test-select-lots]');
+    await click('[data-test-labs-layers]');
+    await click('[data-test-project-geometry-save]');
+    await click('[data-test-project-area-yes]');
+    await click('[data-test-project-area-select-lots]');
+    await click('[data-test-labs-layers]');
+    await click('[data-test-project-geometry-save]');
+    await click('[data-test-rezoning-yes]');
+    await click('[data-test-rezoning-underlying-zoning-yes]');
+    await click('[data-test-rezoning-commercial-overlays-yes]');
+    await click('[data-test-rezoning-special-purpose-districts-yes]');
+    await click('[data-test-alter-zoning]');
+
+    // draw rezoning polygon w/ label
+    await click('[data-test-draw-mock]', { shiftKey: true });
+
+    // click save button
+    await click('[data-test-project-geometry-save]');
+
+    // assert save was successful (we progressed to commercial overlay edit)
+    assert.equal(currentURL(), '/projects/1/edit/geometry-edit?mode=draw&type=commercial-overlays');
+  });
+});

--- a/tests/acceptance/user-can-create-project-with-map-test.js
+++ b/tests/acceptance/user-can-create-project-with-map-test.js
@@ -42,7 +42,7 @@ module('Acceptance | user can create project with map', function(hooks) {
     this.owner.register('component:project-geometries/modes/draw', DrawMode.extend({
       'data-test-draw-mock': true,
       click() {
-        const randomFeatures = randomPolygon(1);
+        const randomFeatures = randomPolygon(1, true);
         this.set('geometricProperty', randomFeatures);
       },
     }));

--- a/tests/helpers/random-geometry.js
+++ b/tests/helpers/random-geometry.js
@@ -3,9 +3,13 @@ import random from '@turf/random';
 // import { helper } from '@ember/component/helper';
 
 const { randomPoint } = random;
-const randomPolygon = function(count) {
+const randomPolygon = function(count, label = false) {
   if (count === 1) {
-    return { type: 'FeatureCollection', features: [{ type: 'Feature', properties: {}, geometry: { type: 'Polygon', coordinates: [[[-73.91304371809123, 40.75800497849508], [-73.91272236764055, 40.75785653226183], [-73.91253338845002, 40.75808671409273], [-73.91285462634531, 40.75823546499302], [-73.91295060921382, 40.758120288754554], [-73.91304371809123, 40.75800497849508]]] } }] };
+    const poly = { type: 'FeatureCollection', features: [{ type: 'Feature', properties: {}, geometry: { type: 'Polygon', coordinates: [[[-73.91304371809123, 40.75800497849508], [-73.91272236764055, 40.75785653226183], [-73.91253338845002, 40.75808671409273], [-73.91285462634531, 40.75823546499302], [-73.91295060921382, 40.758120288754554], [-73.91304371809123, 40.75800497849508]]] } }] };
+    if (label) {
+      poly.features[0].properties.label = 'test-label';
+    }
+    return poly;
   }
 
   if (count === 2) {

--- a/tests/unit/components/project-geometries/modes/draw-test.js
+++ b/tests/unit/components/project-geometries/modes/draw-test.js
@@ -1,0 +1,44 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { currentFeatureIsComplete } from 'labs-applicant-maps/components/project-geometries/modes/draw';
+
+module('Unit | Component | project-geometries/modes/draw', function(hooks) {
+  setupTest(hooks);
+
+  test('currentFeatureIsComplete returns true for modes other than direct_select', function(assert) {
+    const result = currentFeatureIsComplete('simple_select');
+    assert.ok(result);
+  });
+
+  test('currentFeatureIsComplete returns true for empty features', function(assert) {
+    const result = currentFeatureIsComplete('direct_select');
+    assert.ok(result);
+  });
+
+  test('currentFeatureIsComplete returns true for polygons with labels in direct_select mode', function(assert) {
+    const labeledPolygon = {
+      geometry: {
+        type: 'Polygon',
+      },
+      properties: {
+        label: 'test-label',
+      },
+    };
+
+    const result = currentFeatureIsComplete('direct_select', labeledPolygon);
+    assert.ok(result);
+  });
+
+  test('currentFeatureIsComplete returns false for polygons without labels in direct_select mode', function(assert) {
+    const unlabeledPolygon = {
+      geometry: {
+        type: 'Polygon',
+      },
+      properties: {
+      },
+    };
+
+    const result = currentFeatureIsComplete('direct_select', unlabeledPolygon);
+    assert.notOk(result);
+  });
+});


### PR DESCRIPTION
When a user has just created a polygon and the label form is being
displayed, we want to force the user to select a polygon. This is
achieved by disabling the user to switch modes, either by selecting a
new annotation mode or selecting another feature/blank map area. A
top-level property, missingLabel, added to the selected feature is used
to conditionally display the label form as red when the user is blocked
from switching modes to cue them as to why they're stuck

closes #417 