### PR TITLE
378: remove measurement label for right angle annotation

### DIFF
--- a/app/utils/mapbox-gl-draw/annotations/mode.js
+++ b/app/utils/mapbox-gl-draw/annotations/mode.js
@@ -99,6 +99,10 @@ export function toDisplayFeatures(state, geojson, display) {
   geojson.properties.active = (isActiveLine) ? 'true' : 'false';
   if (!isActiveLine) return display(geojson);
 
+  if (geojson.properties.mode === 'draw_annotations:square') {
+    geojson.properties.label = '';
+  }
+
   // Only render the line if it has at least one real coordinate
   if (geojson.geometry.coordinates.length < 2) return null;
   geojson.properties.meta = 'feature';


### PR DESCRIPTION
for square annotations mode, set `geojson.properties.label` to `''` so that label does not show up while drawing the line that is part of the right angle annotation tool. 

Closes #378