### PR TITLE
434: make it so that drawing cursor on zoning maps is crosshair

### DIFF
--- a/app/routes/projects/edit/geometry-edit.js
+++ b/app/routes/projects/edit/geometry-edit.js
@@ -58,6 +58,7 @@ const mapEditingLayerGroups = {
       layers: [
         {
           highlightable: false,
+          clickable: false,
           tooltipable: false,
           style: {
             paint: {


### PR DESCRIPTION
Make `zoning-districts` layer-group `clickable: false` so that pointer cursor does not override drawing cursor. 

Closes #434 