### PR TITLE
435: make project area boundary style visible on area map

### DIFF
--- a/app/utils/project-geom-layers.js
+++ b/app/utils/project-geom-layers.js
@@ -13,9 +13,6 @@ const developmentSiteLayer = {
 const projectAreaLayer = {
   id: 'project-area-line',
   type: 'line',
-  layout: {
-    visibility: 'visible',
-  },
   paint: {
     'line-color': 'rgba(0, 122, 122, 1)',
     'line-width': 2.5,

--- a/app/utils/project-geom-layers.js
+++ b/app/utils/project-geom-layers.js
@@ -9,6 +9,20 @@ const developmentSiteLayer = {
   },
 };
 
+// Project Area
+const projectAreaLayer = {
+  id: 'project-area-line',
+  type: 'line',
+  layout: {
+    visibility: 'visible',
+  },
+  paint: {
+    'line-color': 'rgba(0, 122, 122, 1)',
+    'line-width': 2.5,
+    'line-dasharray': [3, 1],
+  },
+};
+
 // Rezoning Area
 const rezoningAreaLayer = {
   id: 'rezoning-area-line',
@@ -233,6 +247,7 @@ export default {
   c24Layer,
   c25Layer,
   developmentSiteLayer,
+  projectAreaLayer,
   rezoningAreaLayer,
   projectBufferLayer,
   underlyingZoningLayer,


### PR DESCRIPTION
Add `projectAreaLayer` to `project-geom-layers.js` to specify styling for project area boundary that appears on area map. 

Closes #435 