### PR TITLE
Update draw/annotation layout and tooltips

### DIFF
--- a/app/styles/modules/_m-maps.scss
+++ b/app/styles/modules/_m-maps.scss
@@ -298,19 +298,46 @@
   top: 110px;
   left: 10px;
   z-index: 2;
-  background-color: $a11y-yellow;
-  border: 2px solid $a11y-yellow;
   border-radius: 4px;
-  box-shadow: 0 0 0 2px rgba(0,0,0,0.1);
+  box-shadow: 0 0 0 4px rgba(0,0,0,0.1);
+  margin-top: rem-calc(62);
+  margin-bottom: 12px;
 
   > button {
     display: block;
     width: rem-calc(48);
+    height: rem-calc(48);
     background-color: $white;
     padding: rem-calc(10) 0;
     border: 2px solid $a11y-yellow;
+    border-radius: 2px;
+    box-shadow:
+      0 0 0 2px $a11y-yellow;
+
+    &:first-child,
+    &:last-child {
+      position: absolute;
+      left: 0;
+      margin-bottom: 12px;
+      border-radius: 2px;
+      box-shadow:
+        0 0 0 2px $a11y-yellow,
+        0 0 0 4px rgba(0,0,0,0.1);
+    }
 
     &:first-child {
+      bottom: 100%;
+    }
+
+    &:last-child {
+      top: 100%;
+    }
+
+    &:last-child:not(:nth-child(2)) {
+      margin-top: 14px;
+    }
+
+    &:nth-child(2) {
       border-top-right-radius: 6px;
       border-top-left-radius: 6px;
     }
@@ -318,17 +345,6 @@
     &:nth-last-child(2) {
       border-bottom-right-radius: 6px;
       border-bottom-left-radius: 6px;
-    }
-
-    &:last-child {
-      position: absolute;
-      top: 100%;
-      left: 0;
-      margin-top: 12px;
-      border-radius: 2px;
-      box-shadow:
-        0 0 0 2px $a11y-yellow,
-        0 0 0 4px rgba(0,0,0,0.1);
     }
 
     &:hover {

--- a/app/templates/components/project-geometries/modes/draw.hbs
+++ b/app/templates/components/project-geometries/modes/draw.hbs
@@ -2,7 +2,10 @@
   <button class="polygon {{if (eq currentTool 'draw_polygon') 'active'}}" {{action 'handleDrawButtonClick'}}>
     {{fa-icon 'draw-polygon' size='2x' fixedWidth=true}}
     {{#ember-tooltip side='right' tooltipClassName="ember-tooltip draw-tooltip" popperContainer='body'}}
-      <h5 class="small-margin-bottom">Polygon</h5>
+      <h5 class="small-margin-bottom">
+        <span class="text-weight-normal blue-light">Draw:</span>
+        Polygon
+      </h5>
       <p class="small-margin-bottom">Add a new shape. Complete it by clicking the final point a 2nd time.</p>
       <p class="no-margin">Edit an existing shape by selecting it and dragging/deleting its points. Add a new point by clicking the midpoint of a line.</p>
     {{/ember-tooltip}}
@@ -34,7 +37,7 @@
     {{fa-icon 'trash-alt' prefix='far' size='2x' fixedWidth=true}}
     {{#ember-tooltip side='right' tooltipClassName="ember-tooltip draw-tooltip" popperContainer='body'}}
       <h5 class="small-margin-bottom">Trash</h5>
-      <p class="no-margin">Delete a selected shape or point</p>
+      <p class="no-margin">Delete the selected shape or point</p>
     {{/ember-tooltip}}
   </button>
 {{/ember-wormhole}}

--- a/app/templates/components/project-geometries/modes/draw/annotations.hbs
+++ b/app/templates/components/project-geometries/modes/draw/annotations.hbs
@@ -8,7 +8,10 @@
       {{fa-icon 'times' transform='shrink-9 up-3'}}
     </span>
     {{#ember-tooltip side='right' tooltipClassName="ember-tooltip draw-tooltip" popperContainer='body'}}
-      <h5 class="small-margin-bottom">Parallel Measurement</h5>
+      <h5 class="small-margin-bottom">
+        <span class="text-weight-normal blue-light">Annotation:</span>
+        Parallel Measurement
+      </h5>
       <p class="no-margin">Dimension a zoning district boundary that is being drawn based on a parallel offset from either a street-line or a zoning district boundary</p>
     {{/ember-tooltip}}
   </button>
@@ -23,7 +26,10 @@
       {{fa-icon 'times' transform='shrink-9 up-3'}}
     </span>
     {{#ember-tooltip side='right' tooltipClassName="ember-tooltip draw-tooltip" popperContainer='body'}}
-      <h5 class="small-margin-bottom">Point-to-point Measurement</h5>
+      <h5 class="small-margin-bottom">
+        <span class="text-weight-normal blue-light">Annotation:</span>
+        Point-to-point Measurement
+      </h5>
       <p class="no-margin">Dimension a zoning district boundary that is being drawn based on a point-to-point offset</p>
     {{/ember-tooltip}}
   </button>
@@ -36,7 +42,10 @@
       {{fa-icon 'chevron-left' transform='rotate-45 shrink-4'}}
     </span>
     {{#ember-tooltip side='right' tooltipClassName="ember-tooltip draw-tooltip" popperContainer='body'}}
-      <h5 class="small-margin-bottom">Right Angle</h5>
+      <h5 class="small-margin-bottom">
+        <span class="text-weight-normal blue-light">Annotation:</span>
+        Right Angle
+      </h5>
       <p class="small-margin-bottom">Annotate a right angle for a zoning district boundary that is being drawing based on a point-to-point offset.</p>
       <p class="no-margin">Place the first point on the vertex of the angle. Place the second point inside the angle at 45º. Drag to adjust the size and position.</p>
     {{/ember-tooltip}}
@@ -48,7 +57,10 @@
   >
     {{fa-icon 'i-cursor' size='2x' fixedWidth=true transform='shrink-4'}}
     {{#ember-tooltip side='right' tooltipClassName="ember-tooltip draw-tooltip" popperContainer='body'}}
-      <h5 class="small-margin-bottom">Text</h5>
+      <h5 class="small-margin-bottom">
+        <span class="text-weight-normal blue-light">Annotation:</span>
+        Text
+      </h5>
       <p class="no-margin">Add a custom label</p>
     {{/ember-tooltip}}
   </button>
@@ -61,7 +73,10 @@
       <span class="fa-layers-text">℄</span>
     </span>
     {{#ember-tooltip side='right' tooltipClassName="ember-tooltip draw-tooltip" popperContainer='body'}}
-      <h5 class="small-margin-bottom">Centerline</h5>
+      <h5 class="small-margin-bottom">
+        <span class="text-weight-normal blue-light">Annotation:</span> 
+        Centerline
+      </h5>
       <p class="no-margin">Annotate a proposed zoning district boundary that runs midway between two streets</p>
     {{/ember-tooltip}}
   </button>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3272,7 +3272,6 @@ cartobox-promises-utility@nycplanning/cartobox-promises-utility#v1.0.2:
   resolved "https://codeload.github.com/nycplanning/cartobox-promises-utility/tar.gz/57f1c96a0bf03c47e048c30d202643cc49db3c69"
   dependencies:
     ember-cli-babel "^6.6.0"
-    ember-fetch "4.0.1"
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
This PR separates the annotation buttons from the polygon button and adds noticeable "Draw:" and "Annotation:" text to tooltips. 

<img src="https://user-images.githubusercontent.com/409279/54384512-c8bfc700-466a-11e9-81d0-6f0695f8ecff.png" width=300 />

Closes #491. 