### PR TITLE
On init use current geometric prop

### DIFF
--- a/app/components/project-geometries/modes/lots.js
+++ b/app/components/project-geometries/modes/lots.js
@@ -26,11 +26,7 @@ export default class LotsComponent extends Component {
   constructor(...args) {
     super(...args);
 
-    // selectedLots
-    this.set('selectedLots', {
-      type: 'FeatureCollection',
-      features: [],
-    });
+    this.set('selectedLots', this.get('geometricProperty'));
 
     // Add the interactive tax lots layer group to the store
     const interactiveTaxLotsLayerGroup = this.store.createRecord('layer-group', {


### PR DESCRIPTION
This simple change sets the selected lots to the current geometricProperty on init.

Closes #500 