### PR TITLE
492: custom direct_select modes

### DIFF
--- a/app/components/mapbox-gl-draw.js
+++ b/app/components/mapbox-gl-draw.js
@@ -6,16 +6,15 @@ import { next } from '@ember/runloop';
 import { service } from '@ember-decorators/service';
 import { action, computed } from '@ember-decorators/object';
 import { setProperties } from '@ember/object';
-import AnnotationsMode, { DirectSelect_RequiresPolygonLabelMode, annotatable } from 'labs-applicant-maps/utils/mapbox-gl-draw/annotations/mode';
+import AnnotationsMode,
+{
+  CustomDirectSelect,
+  CustomDirectSelectForRezoning,
+  annotatable,
+} from 'labs-applicant-maps/utils/mapbox-gl-draw/annotations/mode';
 import AnnotationsStyles from 'labs-applicant-maps/utils/mapbox-gl-draw/annotations/styles';
 import isEmpty from 'labs-applicant-maps/utils/is-empty';
 
-const DirectSelectUndraggable = MapboxDraw.modes.direct_select;
-
-DirectSelectUndraggable.onFeature = function() {
-  // Enable map.dragPan when user clicks on feature, overrides ability to drag shape
-  this.map.dragPan.enable();
-};
 
 // extend styles
 const styles = [...AnnotationsStyles, ...DefaultMapboxDrawStyles].uniqBy('id');
@@ -27,8 +26,9 @@ export const DefaultDraw = MapboxDraw.bind(null, {
     polygon: true,
     trash: true,
   },
-  modes: Object.assign({
-    direct_select_undraggable: DirectSelectUndraggable,
+  modes: Object.assign(MapboxDraw.modes, {
+    direct_select_rezoning: CustomDirectSelectForRezoning,
+    direct_select: CustomDirectSelect,
     'draw_annotations:linear': AnnotationsMode, // These are identical because they function the same
     'draw_annotations:curved': AnnotationsMode, // but only really need to be named differently
     'draw_annotations:square': AnnotationsMode,
@@ -36,9 +36,7 @@ export const DefaultDraw = MapboxDraw.bind(null, {
     'draw_annotations:centerline': AnnotationsDrawPointMode,
     // duplicate mode with distinct name  to avoid `skipToDirectSelect` trigger when we switch to simple_select for delete
     simple_select_delete: MapboxDraw.modes.simple_select,
-  },
-  MapboxDraw.modes,
-  { direct_select: DirectSelect_RequiresPolygonLabelMode }),
+  }),
   styles,
 });
 

--- a/app/components/project-geometries/modes/draw.js
+++ b/app/components/project-geometries/modes/draw.js
@@ -107,7 +107,7 @@ export default class DrawComponent extends Component {
 
     // can't direct select a point
     if (selectedID && type !== 'Point' && mode === 'simple_select') {
-      draw.changeMode('direct_select', { featureId: selectedID });
+      draw.changeMode(this.get('directSelectMode'), { featureId: selectedID });
     }
 
     this.set('tool', mode);
@@ -146,6 +146,9 @@ export default class DrawComponent extends Component {
   // @type(FeatureCollection)
   @argument
   geometricProperty;
+
+  @argument
+  directSelectMode = 'direct_select';
 
   // @type(FeatureCollection)
   selectedFeature = EmptyFeatureCollection;

--- a/app/templates/components/project-geometries/types/commercial-overlays.hbs
+++ b/app/templates/components/project-geometries/types/commercial-overlays.hbs
@@ -1,5 +1,5 @@
 {{#if isReady}}
-  {{#component modeComponent as |editMode|}}
+  {{#component modeComponent directSelectMode='direct_select_rezoning' as |editMode|}}
     {{editMode.feature-label-form
         options=labelOptions}}
     {{editMode.annotations}}

--- a/app/templates/components/project-geometries/types/special-purpose-districts.hbs
+++ b/app/templates/components/project-geometries/types/special-purpose-districts.hbs
@@ -1,5 +1,5 @@
 {{#if isReady}}
-  {{#component modeComponent as |editMode|}}
+  {{#component modeComponent directSelectMode='direct_select_rezoning' as |editMode|}}
     {{editMode.feature-label-form}}
     {{editMode.annotations}}
   {{/component}}

--- a/app/templates/components/project-geometries/types/underlying-zoning.hbs
+++ b/app/templates/components/project-geometries/types/underlying-zoning.hbs
@@ -1,5 +1,5 @@
 {{#if isReady}}
-  {{#component modeComponent as |editMode|}}
+  {{#component modeComponent directSelectMode='direct_select_rezoning' as |editMode|}}
     {{editMode.feature-label-form
         options=labelOptions}}
     {{editMode.annotations}}
@@ -11,7 +11,7 @@
 {{#ember-wormhole to='geometry-type-draw-explainer'}}
   <div class="fade-in-on-load text-small">
 
-    
+
     <h1 class="header-large small-margin-bottom">
       Rezoning:
       <span class="text-weight-normal" style="display:block;">


### PR DESCRIPTION
Custom `direct_select` modes so that...

1. shapes are not draggable
2. zoning districts require a label before clicking anywhere else

closes #492 