### PR TITLE
383: Change centerline annotation to icon + arrow

### DIFF
--- a/app/components/mapbox-gl-draw.js
+++ b/app/components/mapbox-gl-draw.js
@@ -33,7 +33,7 @@ export const DefaultDraw = MapboxDraw.bind(null, {
     'draw_annotations:curved': AnnotationsMode, // but only really need to be named differently
     'draw_annotations:square': AnnotationsMode,
     'draw_annotations:label': AnnotationsDrawPointMode,
-    'draw_annotations:centerline': AnnotationsDrawPointMode,
+    'draw_annotations:centerline': AnnotationsMode,
     // duplicate mode with distinct name  to avoid `skipToDirectSelect` trigger when we switch to simple_select for delete
     simple_select_delete: MapboxDraw.modes.simple_select,
   },

--- a/app/templates/components/project-geometries/modes/draw/annotations.hbs
+++ b/app/templates/components/project-geometries/modes/draw/annotations.hbs
@@ -73,11 +73,8 @@
       <span class="fa-layers-text">℄</span>
     </span>
     {{#ember-tooltip side='right' tooltipClassName="ember-tooltip draw-tooltip" popperContainer='body'}}
-      <h5 class="small-margin-bottom">
-        <span class="text-weight-normal blue-light">Annotation:</span> 
-        Centerline
-      </h5>
-      <p class="no-margin">Annotate a proposed zoning district boundary that runs midway between two streets</p>
+      <h5 class="small-margin-bottom">Centerline</h5>
+      <p class="no-margin">Annotate a proposed zoning district boundary that runs midway between two streets. Place the first point where you would like to place the icon. The second point will be an arrow directed at the actual centerline.</p>
     {{/ember-tooltip}}
   </button>
   {{yield}}


### PR DESCRIPTION
- Edits the centerline annotation to consist of an icon (first point) and an arrow (second point). 
- Uses `lineBearing` and trig to calculate `icon-translate` values to position the icon offset from the end of the line based on lineBearing

Closes #383 