### PR TITLE
Fix bug allowing special districts on area map

### DIFF
--- a/app/templates/components/map-form.hbs
+++ b/app/templates/components/map-form.hbs
@@ -230,8 +230,8 @@
             {{/if}}
 
             {{!-- Ad-hoc source and layer for showing commercial overlays --}}
-            {{#if model.project.proposedSpecialPurposeDistricts}}
-              {{#map.source options=(mapbox-geojson-source model.project.proposedSpecialPurposeDistricts) as |source|}}
+            {{#if model.project.specialPurposeDistricts}}
+              {{#map.source options=(mapbox-geojson-source model.project.specialPurposeDistricts) as |source|}}
                 {{source.layer
                   layer=projectGeomLayers.proposedSpecialPurposeDistrictsLayer
                   before='boundary_country'

--- a/app/utils/project-geom-layers.js
+++ b/app/utils/project-geom-layers.js
@@ -196,7 +196,7 @@ const proposedSpecialPurposeDistrictsLayer = {
   type: 'fill',
   paint: {
     'fill-color': 'rgba(94, 102, 51, 1)',
-    'fill-opacity': 0.2,
+    'fill-opacity': 0.3,
   },
 };
 
@@ -206,7 +206,7 @@ const proposedSpecialPurposeDistrictsLabelsLayer = {
   layout: {
     'symbol-placement': 'point',
     'text-field': '{label}',
-    'text-size': 12,
+    'text-size': 14,
     visibility: 'visible',
     'symbol-avoid-edges': false,
     'text-offset': [


### PR DESCRIPTION
- Fix a minor spelling error to allow special purpose districts to show up on area map
- The styling was also making it hard to see on the area map so I made it more opaque (0.2 to 0.3) and made the text label bigger (12 to 14)--> if anyone rejects to these I can change them again

Closes #511 