### PR TITLE
504: Load icon images when map is created, instead of when annotations are drawn

### DIFF
--- a/app/templates/components/project-geometries/utils/annotations-renderer.hbs
+++ b/app/templates/components/project-geometries/utils/annotations-renderer.hbs
@@ -1,6 +1,3 @@
-{{map.image 'arrow' '/img/arrow.png'}}
-{{map.image 'centerline' '/img/centerline.png'}}
-
 {{#each displayLayers as | layer |}}
   {{map.layer layer=layer}}
 {{/each}}

--- a/app/templates/components/project-geometry-renderer.hbs
+++ b/app/templates/components/project-geometry-renderer.hbs
@@ -117,6 +117,8 @@
   {{/map.source}}
 {{/if}}
 
+{{ map.image 'arrow' '/img/arrow.png' }}
+{{ map.image 'centerline' '/img/centerline.png' }}
 {{#if (not (is-empty model.annotations))}}
   {{project-geometries/utils/annotations-renderer map=map annotations=model.annotations}}
 {{/if}}


### PR DESCRIPTION
to avoid race condition --> missing arrows