### PR TITLE
add feedback links

### DIFF
--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -16,6 +16,8 @@
           <small style="display:block;margin-top:0.5em;">to learn more about the application review process</small>
         </a>
 
+      <p class="help-text">For questions about your project, please coordinate with your assigned DCP staff members. To report technical problems with this website, please <strong><a href="https://github.com/NYCPlanning/labs-applicantmaps/issues" target="_blank">create GitHub issues</a></strong>, tweet <strong><a href="https://twitter.com/nycplanninglabs" target="_blank">@NYCPlanningLabs</a></strong>, or <strong><a href="mailto:Labs_DL@planning.nyc.gov" target="_blank">email</a></strong>.</p>
+
       </div>
       <div class="cell large-5">
 


### PR DESCRIPTION
Adds feedback links to the bottom of the landing page. This will be a temporary solution until we figure out a more standardized feedback UI strategy to implement across our apps.