### PR TITLE
Update intersecting zoning query to use alias view in Carto

### DIFF
--- a/app/utils/queries/intersecting-zoning-query.js
+++ b/app/utils/queries/intersecting-zoning-query.js
@@ -23,7 +23,7 @@ export default async (developmentSite) => {
         4326)::geometry AS the_geom
       )
       SELECT ST_Intersection(zoning.the_geom, buffer.the_geom) AS the_geom, zonedist AS label, cartodb_id AS id
-      FROM planninglabs.zoning_districts_v201809 zoning, buffer
+      FROM planninglabs.zoning_districts zoning, buffer
       WHERE ST_Intersects(zoning.the_geom,buffer.the_geom)
     `;
 

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -35,6 +35,7 @@ export default function() {
 
   // map interceptions
   this.passthrough('https://layers-api.planninglabs.nyc/**');
+  this.passthrough('https://labs-layers-api-staging.herokuapp.com/**');
   this.passthrough('https://tiles.planninglabs.nyc/**');
   this.passthrough('https://layers-api-staging.planninglabs.nyc/**');
   this.passthrough('https://raw.githubusercontent.com/**');


### PR DESCRIPTION
Before, it was pointing to an old version of the zoning data.

Now, this points to the aliased view for the zoning in Carto, which is refreshed on a regular basis.

Closes #579 
