### PR TITLE
2949 Updated xmlhttprequest-ssl

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,8 @@
     "ember-fetch": "5.1.3",
     "mapbox-gl": "0.50.0",
     "ember-concurrency": "0.9.0",
-    "ember-power-select": "2.2.3"
+    "ember-power-select": "2.2.3",
+    "xmlhttprequest-ssl": "^1.6.2"
   },
   "lint-staged": {
     "*.js": "eslint --cache --fix"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12237,9 +12237,10 @@ xmldom@^0.1.19:
   version "0.1.27"
   resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.27.tgz#d501f97b3bdb403af8ef9ecc20573187aadac0e9"
 
-xmlhttprequest-ssl@~1.5.4:
-  version "1.5.5"
-  resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz#c2876b06168aadc40e57d97e81191ac8f4398b3e"
+xmlhttprequest-ssl@^1.6.2, xmlhttprequest-ssl@~1.5.4:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.3.tgz#03b713873b01659dfa2c1c5d056065b27ddc2de6"
+  integrity sha512-3XfeQE/wNkvrIktn2Kf0869fC0BN6UpydVasGIeSm2B1Llihf7/0UfZM+eCkOw3P7bP4+qPgqhm7ZoxuJtFU0Q==
 
 xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.1"


### PR DESCRIPTION
Critical security update.
Closes part of AB#2949